### PR TITLE
Swordjack: Feature LLM Integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,93 +2,97 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## What ARK is
+## Rule You Should Follow (Hard Constraints)
 
-Agile Resource Kernel (ARK) is a Python automation framework for corporate resource management, built around a JSON-driven workflow engine with AI/LLM integration. It is a library (no `setup.py`/`pyproject.toml`), so code is imported relative to the repo root rather than pip-installed.
+### 1. Think Before Coding
 
-## Environment & commands
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
 
-The project uses a conda environment named `ark` (Python 3.13). Set it up with:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
 
-```bash
-conda env create -f environment.yml
-conda activate ark
+### 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+  Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+- **Cleanup**: Remove imports/variables/functions that YOUR changes made unused. Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
 ```
 
-Tests run with pytest **from the repo root** (the `ark` package must be importable from the current directory — there is no installed package):
+## Quick Context (Cheatsheet)
 
-```bash
-python -m pytest                                          # all tests
-python -m pytest test/workflow/test_workflow.py           # one file
-python -m pytest test/workflow/test_workflow.py::test_general_reload_pass   # one test
-```
+**What ARK is**: Agile Resource Kernel (ARK) is a Python automation framework built around a JSON-driven workflow engine with AI/LLM integration. It is a library (no `setup.py`), so code is imported relative to the repo root rather than pip-installed.
 
-There is no build step and no configured linter. Code style follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) by convention (see Conventions below).
+**Environment & Testing**:
 
-Known dependency gap: `Pillow` (`PIL`) is imported by `ark/core/image_service.py` and the LLM module but is **not** declared in `environment.yml`. A fresh env from that file will fail to `import ark.llm` until Pillow is installed.
+- Python 3.13 via conda. Setup: `conda env create -f environment.yml && conda activate ark`
+- _Note: `Pillow` is required but missing from `environment.yml`. Install it manually if needed._
+- Tests use `pytest` and **must** be run from the repo root:
+  - `python -m pytest` (all tests)
+  - `python -m pytest test/workflow/test_workflow.py` (specific file)
 
-## Module map
+**Conventions**:
 
-Four packages under `ark/`, each re-exporting its public surface through `__init__.py`:
+- Type-annotate every parameter/return value with docstrings.
+- Double quotes (`"`) are the primary string quote.
+- Files begin with a docblock (`@File`, `@Created`, `@Author`, `@Contact`).
+- Tests mirror source tree under `test/` (e.g. `test/core/test_logger.py`).
+- Branches: `main` (release), `develop` (integration). Format: `<name>/<type>_<desc>`.
 
-- `ark.core` — shared infrastructure: global `LOGGER` (colorlog), `file_system` helpers, `image_service`. Per the developer guide, OS/file/logging operations belong here; reuse these rather than reinventing them.
-- `ark.workflow` — the JSON workflow engine (the heart of the project).
-- `ark.llm` — OpenAI-compatible chat client with tool calling and multimodal input.
-- `ark.locale` — locale resolution from phone numbers and country/language metadata.
+## Architectural Boundaries
 
-## Workflow engine architecture (`ark/workflow`)
+### `ark/llm` — LLM Client & Tool Engine
 
-This is the most intricate subsystem and spans `workflow.py`, `config.py`, and `database.py`. A workflow is defined by a JSON "order" file describing a nested tree of work units.
+This module is strictly separated into Data -> Logic -> Adapters to maintain vendor neutrality.
 
-**Execution entity hierarchy** (all in `workflow.py`):
+- **`entities.py` (Data DTOs)**: Defines `LLMResponse`, `TokenUsage`, and `ToolCall`. These represent pure data boundaries. `ToolCall` is the universal representation of what the model wants to do.
+- **`tools/` (Engine Logic)**: `FunctionTool` and `ToolSet`. Represents local capabilities. `FunctionTool` automatically extracts JSON schemas from Python callable signatures and docstrings (manual overrides allowed). `ToolSet` blindly executes `ToolCall` requests; it has zero knowledge of OpenAI or Anthropic formats.
+- **`providers/` (Translators/Adapters)**: `OpenAIChat` and `AnthropicMessages`. These handle the actual network requests, multi-turn loops, and streaming accumulation. They are responsible for translating the neutral `FunctionTool` and `ToolCall` objects into their specific vendor's JSON dialects right before transmission.
 
-- `ExecutionEntity` — base class: identification, status, tree navigation, SQLite sync, pickle snapshot/load.
-- `WorkUnit` — a single step. Its `api` key is mapped to a Python callable via the global `UNIT_API_MAPPER` (in `config.py`). Performs self-inspection of arguments against the callable's signature at init.
-- `WorkFlow` — an ordered list of `WorkUnit`s; executes them sequentially, collecting errors without halting on non-fatal ones.
-- `ControlWorkUnit` → `IterativeWorkUnit` → `LoopWorkUnit` / `ClusterBatchWorkUnit` — control-flow units that wrap a loop/batch body as sub-`WorkFlow`s. `ClusterBatchWorkUnit.execute` is still a stub copied from the loop logic.
-- `GeneralWorkUnit` — the outermost entry point that carries the entire workflow. Use `GeneralWorkUnit.from_json_filepath(...)` to load and `.execute()` to run.
+### `ark/workflow` — JSON Workflow Engine
 
-**How APIs are registered**: callables are added to `UNIT_API_MAPPER` (a module-global dict) by updating it at import time — see `WIDGET_API_MAPPER` in `config.py` and `test/workflow/pseudo_api.py` for the pattern. A `WorkUnit`'s `api` string must already be present in this dict at init or initialization fails.
+A nested tree of execution units driven by JSON "order" files.
 
-**Data flow between units**: each `WorkFlow` has an `intermediate_data_mapper` (this layer's results) plus `outer_data_mappers` (inherited from parent layers). In JSON args, a value wrapped in backticks like `` "`fruit_1`" `` is a _variable reference_ resolved from these mappers at execution time (see `JsonConfigVariableFormatter` in `config.py`), not a literal. `store_as` names the key a unit's return value is written to.
+- **Execution Hierarchy**: `ExecutionEntity` (base, handles SQLite sync) -> `WorkUnit` (single step mapped to a Python API) -> `WorkFlow` (sequential list of units) -> `GeneralWorkUnit` (outermost entry point).
+- **APIs**: Registered via `UNIT_API_MAPPER` in `config.py` at import time.
+- **Data Flow**: Handled via `intermediate_data_mapper` and `outer_data_mappers`. Variables wrapped in backticks (e.g. ``"`var_name`"``) are dynamically resolved at runtime.
+- **Persistence**: Statuses auto-sync to SQLite via `database.py`. `GeneralWorkUnit` can pickle snapshot state (`save_snapshot=True`) for resume/continue computing.
 
-**Status & control flow**: `StatusCode` (in `config.py`) defines all execution states and the status _groups_ (e.g. `error_or_pause_statuses`, `skippable_statuses`, `unexecutable_statuses`) that drive how errors and pauses propagate up the tree and which units are skipped on re-run. Setting `.status` to an executed state auto-syncs to SQLite.
+### Other Modules
 
-**Persistence & continue-computing**:
-
-- SQLite (via SQLAlchemy, `database.py`) records each entity's status keyed by its `identifier`, which is `"{api_key}@{locator}"` (e.g. `checkpoint_error@4:loop_1:0`). `locate_by_identifier` / `locate` walk the tree by this locator.
-- `GeneralWorkUnit` with `save_snapshot=True` pickles its full state on exit. Reload an updated JSON via `reload_json_filepath(...)`; only units whose args changed are marked `SUSPECIOUS_UPDATES` and re-run — the architecture (unit tree shape) must be unchanged or reload is rejected.
-
-**Working-directory side effects**: `GeneralWorkUnit` and iterative units `chdir` into the working directory during execution and back to the launch directory (`BASE_DIRECTORY`) afterward. When `save_snapshot=False` and `debug=False`, `from_dict` sleeps 5s with a cancel warning before proceeding.
-
-The `ark/workflow/README.md` has a runnable quick-start order and the load/reload API. Test fixtures in `test/workflow/data/*.json` are good concrete examples.
-
-## LLM module architecture (`ark/llm`)
-
-- `providers/base.py` — `BaseLLMClient` abstract interface (`generate`, `generate_stream`) plus `build_user_message_content` for multimodal messages.
-- `providers/openai_chat.py` — `OpenAIChat`, the concrete OpenAI-compatible client. `ask()` runs a multi-turn tool-calling loop (bounded by `max_tool_rounds`) over the lower-level `generate`/`generate_stream`; both streaming and non-streaming paths are supported and history is preserved on error.
-- `entities.py` — `LLMResponse` and `TokenUsage` dataclasses; every client method returns the standardized `LLMResponse`.
-- `tools/base.py` — `FunctionTool`, `FunctionToolParameter`, `ToolSet` implement OpenAI-style function calling. A tool's Python callable is supplied via `tool_function_mapper`; `ToolSet.execute_tool_calls` runs them and formats `role: "tool"` messages.
-- Multimodal images go through `ark/core/image_service.convert_image_to_data_url` (PIL image → PNG data URL).
-
-LLM tests mock the `OpenAI` client (`unittest.mock.patch` on `ark.llm.providers.openai_chat.OpenAI`); they never hit a live API.
-
-## Locale module architecture (`ark/locale`)
-
-`LocaleManager` (`locale_manager.py`) is both a resolver and a per-locale metadata container. It resolves a locale from a raw phone number (`phone.py`, backed by `phonenumbers`) and looks up country/language names and flags (`country.py`, backed by `pycountry`). Internal codes are lowercase-underscore (`zh_cn`); `code_bcp47` gives the `zh-CN` form.
-
-## Conventions
-
-From `docs/developer.md` and `.gemini/GEMINI.md`:
-
-- Type-annotate every function/method parameter and return value, with docstrings explaining them.
-- Use double quotes as the primary string quote.
-- Start each Python file with a header docblock containing `@File`, `@Created`, `@Author`, `@Contact` (see any existing file, e.g. `ark/core/logger.py`).
-- Favor simple, minimal changes; avoid hardcoding constant strings/numbers — many are centralized as module-level constants (e.g. the `*_KEY` / `*_LABEL` names at the top of `workflow.py`).
-- Tests mirror the source tree under `test/` with a `test_` filename prefix (`ark/core/logger.py` → `test/core/test_logger.py`).
-
-## Version control
-
-- `develop` is the integration branch for ongoing work; `main` is the public release branch.
-- Branch naming: `<your_name>/<type>_<description>`, where `<type>` is `feature`, `fix`, `hotfix`, or `docs` (e.g. `tom/feature_eat_watermelon`). `hotfix_*` branches target `main` directly; the rest target `develop`.
-- Merged branches are renamed with a `zarchive/` prefix to mark them retired.
+- **`ark/core`**: OS/file/logging (`colorlog`)/image helpers. Reuse these; do not reinvent them.
+- **`ark/locale`**: Resolves locales from phone numbers (`phonenumbers`) and country metadata (`pycountry`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What ARK is
+
+Agile Resource Kernel (ARK) is a Python automation framework for corporate resource management, built around a JSON-driven workflow engine with AI/LLM integration. It is a library (no `setup.py`/`pyproject.toml`), so code is imported relative to the repo root rather than pip-installed.
+
+## Environment & commands
+
+The project uses a conda environment named `ark` (Python 3.13). Set it up with:
+
+```bash
+conda env create -f environment.yml
+conda activate ark
+```
+
+Tests run with pytest **from the repo root** (the `ark` package must be importable from the current directory — there is no installed package):
+
+```bash
+python -m pytest                                          # all tests
+python -m pytest test/workflow/test_workflow.py           # one file
+python -m pytest test/workflow/test_workflow.py::test_general_reload_pass   # one test
+```
+
+There is no build step and no configured linter. Code style follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) by convention (see Conventions below).
+
+Known dependency gap: `Pillow` (`PIL`) is imported by `ark/core/image_service.py` and the LLM module but is **not** declared in `environment.yml`. A fresh env from that file will fail to `import ark.llm` until Pillow is installed.
+
+## Module map
+
+Four packages under `ark/`, each re-exporting its public surface through `__init__.py`:
+
+- `ark.core` — shared infrastructure: global `LOGGER` (colorlog), `file_system` helpers, `image_service`. Per the developer guide, OS/file/logging operations belong here; reuse these rather than reinventing them.
+- `ark.workflow` — the JSON workflow engine (the heart of the project).
+- `ark.llm` — OpenAI-compatible chat client with tool calling and multimodal input.
+- `ark.locale` — locale resolution from phone numbers and country/language metadata.
+
+## Workflow engine architecture (`ark/workflow`)
+
+This is the most intricate subsystem and spans `workflow.py`, `config.py`, and `database.py`. A workflow is defined by a JSON "order" file describing a nested tree of work units.
+
+**Execution entity hierarchy** (all in `workflow.py`):
+
+- `ExecutionEntity` — base class: identification, status, tree navigation, SQLite sync, pickle snapshot/load.
+- `WorkUnit` — a single step. Its `api` key is mapped to a Python callable via the global `UNIT_API_MAPPER` (in `config.py`). Performs self-inspection of arguments against the callable's signature at init.
+- `WorkFlow` — an ordered list of `WorkUnit`s; executes them sequentially, collecting errors without halting on non-fatal ones.
+- `ControlWorkUnit` → `IterativeWorkUnit` → `LoopWorkUnit` / `ClusterBatchWorkUnit` — control-flow units that wrap a loop/batch body as sub-`WorkFlow`s. `ClusterBatchWorkUnit.execute` is still a stub copied from the loop logic.
+- `GeneralWorkUnit` — the outermost entry point that carries the entire workflow. Use `GeneralWorkUnit.from_json_filepath(...)` to load and `.execute()` to run.
+
+**How APIs are registered**: callables are added to `UNIT_API_MAPPER` (a module-global dict) by updating it at import time — see `WIDGET_API_MAPPER` in `config.py` and `test/workflow/pseudo_api.py` for the pattern. A `WorkUnit`'s `api` string must already be present in this dict at init or initialization fails.
+
+**Data flow between units**: each `WorkFlow` has an `intermediate_data_mapper` (this layer's results) plus `outer_data_mappers` (inherited from parent layers). In JSON args, a value wrapped in backticks like `` "`fruit_1`" `` is a _variable reference_ resolved from these mappers at execution time (see `JsonConfigVariableFormatter` in `config.py`), not a literal. `store_as` names the key a unit's return value is written to.
+
+**Status & control flow**: `StatusCode` (in `config.py`) defines all execution states and the status _groups_ (e.g. `error_or_pause_statuses`, `skippable_statuses`, `unexecutable_statuses`) that drive how errors and pauses propagate up the tree and which units are skipped on re-run. Setting `.status` to an executed state auto-syncs to SQLite.
+
+**Persistence & continue-computing**:
+
+- SQLite (via SQLAlchemy, `database.py`) records each entity's status keyed by its `identifier`, which is `"{api_key}@{locator}"` (e.g. `checkpoint_error@4:loop_1:0`). `locate_by_identifier` / `locate` walk the tree by this locator.
+- `GeneralWorkUnit` with `save_snapshot=True` pickles its full state on exit. Reload an updated JSON via `reload_json_filepath(...)`; only units whose args changed are marked `SUSPECIOUS_UPDATES` and re-run — the architecture (unit tree shape) must be unchanged or reload is rejected.
+
+**Working-directory side effects**: `GeneralWorkUnit` and iterative units `chdir` into the working directory during execution and back to the launch directory (`BASE_DIRECTORY`) afterward. When `save_snapshot=False` and `debug=False`, `from_dict` sleeps 5s with a cancel warning before proceeding.
+
+The `ark/workflow/README.md` has a runnable quick-start order and the load/reload API. Test fixtures in `test/workflow/data/*.json` are good concrete examples.
+
+## LLM module architecture (`ark/llm`)
+
+- `providers/base.py` — `BaseLLMClient` abstract interface (`generate`, `generate_stream`) plus `build_user_message_content` for multimodal messages.
+- `providers/openai_chat.py` — `OpenAIChat`, the concrete OpenAI-compatible client. `ask()` runs a multi-turn tool-calling loop (bounded by `max_tool_rounds`) over the lower-level `generate`/`generate_stream`; both streaming and non-streaming paths are supported and history is preserved on error.
+- `entities.py` — `LLMResponse` and `TokenUsage` dataclasses; every client method returns the standardized `LLMResponse`.
+- `tools/base.py` — `FunctionTool`, `FunctionToolParameter`, `ToolSet` implement OpenAI-style function calling. A tool's Python callable is supplied via `tool_function_mapper`; `ToolSet.execute_tool_calls` runs them and formats `role: "tool"` messages.
+- Multimodal images go through `ark/core/image_service.convert_image_to_data_url` (PIL image → PNG data URL).
+
+LLM tests mock the `OpenAI` client (`unittest.mock.patch` on `ark.llm.providers.openai_chat.OpenAI`); they never hit a live API.
+
+## Locale module architecture (`ark/locale`)
+
+`LocaleManager` (`locale_manager.py`) is both a resolver and a per-locale metadata container. It resolves a locale from a raw phone number (`phone.py`, backed by `phonenumbers`) and looks up country/language names and flags (`country.py`, backed by `pycountry`). Internal codes are lowercase-underscore (`zh_cn`); `code_bcp47` gives the `zh-CN` form.
+
+## Conventions
+
+From `docs/developer.md` and `.gemini/GEMINI.md`:
+
+- Type-annotate every function/method parameter and return value, with docstrings explaining them.
+- Use double quotes as the primary string quote.
+- Start each Python file with a header docblock containing `@File`, `@Created`, `@Author`, `@Contact` (see any existing file, e.g. `ark/core/logger.py`).
+- Favor simple, minimal changes; avoid hardcoding constant strings/numbers — many are centralized as module-level constants (e.g. the `*_KEY` / `*_LABEL` names at the top of `workflow.py`).
+- Tests mirror the source tree under `test/` with a `test_` filename prefix (`ark/core/logger.py` → `test/core/test_logger.py`).
+
+## Version control
+
+- `develop` is the integration branch for ongoing work; `main` is the public release branch.
+- Branch naming: `<your_name>/<type>_<description>`, where `<type>` is `feature`, `fix`, `hotfix`, or `docs` (e.g. `tom/feature_eat_watermelon`). `hotfix_*` branches target `main` directly; the rest target `develop`.
+- Merged branches are renamed with a `zarchive/` prefix to mark them retired.

--- a/ark/core/image_service.py
+++ b/ark/core/image_service.py
@@ -1,0 +1,42 @@
+#! python3
+# -*- encoding: utf-8 -*-
+"""
+@File   :   image_service.py
+@Created:   2026/06/05 00:18
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+# Here put the import lib.
+import io
+import base64
+from typing import List, Optional
+
+from PIL import Image as PILImage
+
+
+def convert_image_to_data_url(image: PILImage.Image) -> str:
+    """Convert a PIL image instance to a PNG data URL string.
+
+    This method standardizes the output to PNG format, making it generic and
+    unaffected by the source image's original format. PNG is chosen for its
+    lossless quality and universal support for transparency (alpha channel),
+    ensuring maximum compatibility with multimodal LLM inputs.
+
+    Args:
+        image (PIL.Image.Image): The input image to be encoded.
+
+    Returns:
+        image_data_url (str): Base64 data URL string (e.g. ``"data:image/png;base64,..."``).
+    """
+    # Standardize image mode to handle various source modes (like CMYK, LAB, etc.)
+    # PNG natively supports RGB, RGBA, L (grayscale), and P (indexed).
+    # If the mode is not among these, we convert to RGBA to ensure compatibility and preserve transparency.
+    if image.mode not in ("RGB", "RGBA", "L", "P"):
+        image = image.convert("RGBA")
+
+    buf = io.BytesIO()
+    # Save as PNG which is a robust, lossless format supported by all major AI APIs.
+    image.save(buf, format="PNG")
+    image_base64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+    return f"data:image/png;base64,{image_base64}"

--- a/ark/core/image_service.py
+++ b/ark/core/image_service.py
@@ -2,7 +2,7 @@
 # -*- encoding: utf-8 -*-
 """
 @File   :   image_service.py
-@Created:   2026/06/05 00:18
+@Created:   2026/03/06 12:00
 @Author :   SwordJack
 @Contact:   https://github.com/SwordJack/
 """
@@ -10,24 +10,23 @@
 # Here put the import lib.
 import io
 import base64
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from PIL import Image as PILImage
 
 
-def convert_image_to_data_url(image: PILImage.Image) -> str:
-    """Convert a PIL image instance to a PNG data URL string.
+def __encode_image_to_png_base64(image: PILImage.Image) -> str:
+    """Standardize a PIL image to PNG and return its base64-encoded payload.
 
-    This method standardizes the output to PNG format, making it generic and
-    unaffected by the source image's original format. PNG is chosen for its
-    lossless quality and universal support for transparency (alpha channel),
-    ensuring maximum compatibility with multimodal LLM inputs.
+    PNG is chosen for its lossless quality and universal support for
+    transparency (alpha channel), ensuring maximum compatibility with
+    multimodal LLM inputs regardless of the source image's original format.
 
     Args:
         image (PIL.Image.Image): The input image to be encoded.
 
     Returns:
-        image_data_url (str): Base64 data URL string (e.g. ``"data:image/png;base64,..."``).
+        image_base64 (str): The base64-encoded PNG payload (no data-URL prefix).
     """
     # Standardize image mode to handle various source modes (like CMYK, LAB, etc.)
     # PNG natively supports RGB, RGBA, L (grayscale), and P (indexed).
@@ -38,5 +37,36 @@ def convert_image_to_data_url(image: PILImage.Image) -> str:
     buf = io.BytesIO()
     # Save as PNG which is a robust, lossless format supported by all major AI APIs.
     image.save(buf, format="PNG")
-    image_base64 = base64.b64encode(buf.getvalue()).decode("utf-8")
-    return f"data:image/png;base64,{image_base64}"
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+def convert_image_to_data_url(image: PILImage.Image) -> str:
+    """Convert a PIL image instance to a PNG data URL string.
+
+    This method standardizes the output to PNG format, making it generic and
+    unaffected by the source image's original format. Used by OpenAI-compatible
+    multimodal inputs, which expect an ``image_url`` data URL.
+
+    Args:
+        image (PIL.Image.Image): The input image to be encoded.
+
+    Returns:
+        image_data_url (str): Base64 data URL string (e.g. ``"data:image/png;base64,..."``).
+    """
+    return f"data:image/png;base64,{__encode_image_to_png_base64(image)}"
+
+
+def convert_image_to_base64(image: PILImage.Image) -> Tuple[str, str]:
+    """Convert a PIL image instance to a PNG media type and base64 payload.
+
+    Used by APIs (such as Anthropic Messages) that expect the media type and
+    the raw base64 data as separate fields rather than a combined data URL.
+
+    Args:
+        image (PIL.Image.Image): The input image to be encoded.
+
+    Returns:
+        A tuple of ``(media_type, image_base64)`` where ``media_type`` is
+        ``"image/png"`` and ``image_base64`` is the base64-encoded PNG payload.
+    """
+    return "image/png", __encode_image_to_png_base64(image)

--- a/ark/llm/README.md
+++ b/ark/llm/README.md
@@ -11,7 +11,7 @@ The design goal is that swapping providers should not change calling code: tools
 ## Features
 
 - **Provider-neutral surface**: `OpenAIChat` and `AnthropicMessages` share the same public methods and return the same `LLMResponse`, so they are drop-in interchangeable.
-- **Neutral tool format with bidirectional conversion**: a single `FunctionTool` renders to either OpenAI (`to_openai_schema`) or Anthropic (`to_anthropic_schema`) and ingests from either (`from_openai_schema` / `from_anthropic_schema`). No vendor format is treated as the canonical one.
+- **Neutral tool format with auto-generated schemas**: a single `FunctionTool` can automatically extract its `name`, `description`, and JSON `parameters_schema` directly from the signature and docstring of a mapped Python callable. No vendor format is treated as the canonical one, and providers translate the neutral `ToolCall` on the fly.
 - **Multi-turn tool calling**: `ask()` runs a bounded recursive tool-calling loop (`max_tool_rounds`), executing Python callables and feeding results back to the model.
 - **Streaming and non-streaming**: both paths are implemented for each provider; streaming yields incremental text/reasoning chunks then a final summary carrying tool calls and usage.
 - **Extended thinking**: opt-in via `thinking` (e.g. `{"type": "adaptive"}` for Anthropic); thinking text surfaces into `LLMResponse.reasoning_content`.
@@ -47,29 +47,56 @@ for chunk in client.ask("Count from 1 to 5.", stream=True):
 
 ### Tool calling
 
-Tools are defined once in the neutral (OpenAI-shaped) format and work with either provider.
+Tools are defined once in the neutral format and work with either provider. You can let the framework automatically generate the JSON schema from your Python function's signature and docstring, or explicitly provide them to override this behavior.
+
+#### Option A: Automatic Generation (Default)
 
 ```python
-def get_weather(city: str):
+from ark.llm.tools import FunctionTool
+
+def get_weather(city: str) -> tuple[bool, str]:
+    """Get the current weather for a city.
+    
+    Args:
+        city: The name of the city.
+    """
     return True, f"It is 22C and sunny in {city}."  # (is_success, content)
 
-weather_tool = {
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get the current weather for a city.",
-        "parameters": {
-            "type": "object",
-            "properties": {"city": {"type": "string"}},
-            "required": ["city"],
-        },
-    },
-}
+# Automatically extracts name, description, and parameter types from the callable
+weather_tool = FunctionTool(get_weather)
+```
 
+#### Option B: Explicit Overrides (Manual Schema)
+
+If you need precise control over the metadata and parameters schema exposed to the LLM—or want to decouple the JSON-Schema from the Python function signature—you can explicitly provide `name`, `description`, and `parameters_schema` to override auto-generation:
+
+```python
+from ark.llm.tools import FunctionTool
+
+# Explicitly override metadata and schema manually
+weather_tool = FunctionTool(
+    mapped_callable=get_weather,
+    name="get_weather_override",
+    description="Fetch the current weather condition and temperature for a given city.",
+    parameters_schema={
+        "type": "object",
+        "properties": {
+            "city": {
+                "type": "string",
+                "description": "The target city name (e.g. 'Paris', 'Tokyo')"
+            }
+        },
+        "required": ["city"]
+    }
+)
+```
+
+With either option, wire the tool into the client:
+
+```python
 client = AnthropicMessages(
     api_key="sk-ant-...",
     tools=[weather_tool],
-    tool_function_mapper={"get_weather": get_weather},
 )
 resp = client.ask("What's the weather in Paris? Use the tool.")
 print(resp.content)                       # final answer after the tool round
@@ -87,11 +114,11 @@ print(resp.content)            # final answer
 
 ## Module Structure
 
-- `entities.py` — `LLMResponse` and `TokenUsage` dataclasses; the standardized return type for every client method.
+- `entities.py` — `LLMResponse`, `TokenUsage`, and `ToolCall` dataclasses; the standardized provider-neutral data types used for inputs and returns.
 - `providers/base.py` — `BaseLLMClient` abstract interface (`generate`, `generate_stream`) plus `build_user_message_content` for multimodal messages.
 - `providers/openai_chat.py` — `OpenAIChat`, the OpenAI Chat Completion compatible client.
 - `providers/anthropic_messages.py` — `AnthropicMessages`, the Anthropic Messages compatible client (named after the Messages API, mirroring how `OpenAIChat` is named after the Chat Completion API).
-- `tools/base.py` — `FunctionTool`, `FunctionToolParameter`, `ToolSet`; the neutral tool representation and per-vendor schema conversion / execution.
+- `tools/base.py` — `FunctionTool`, `ToolSet`; the neutral tool representation and execution engine.
 
 Image helpers live in `ark/core/image_service.py` (`convert_image_to_data_url` for OpenAI, `convert_image_to_base64` for Anthropic).
 

--- a/ark/llm/README.md
+++ b/ark/llm/README.md
@@ -1,0 +1,118 @@
+# LLM Module
+
+> 中文文档见 [README.zh-cn.md](./README.zh-cn.md)
+
+## Introduction
+
+The `ark.llm` module is a provider-neutral client layer for Large Language Models. It exposes one consistent surface (`ask` / `generate` / `generate_stream`) across different vendor APIs, returns a standardized `LLMResponse`, and supports multi-turn tool calling, multimodal image input, streaming, and extended thinking. Two providers are interchangeable today: OpenAI Chat Completion compatible (`OpenAIChat`) and Anthropic Messages compatible (`AnthropicMessages`).
+
+The design goal is that swapping providers should not change calling code: tools are defined once in a neutral format and rendered to each vendor's wire schema on demand; every method returns the same `LLMResponse`.
+
+## Features
+
+- **Provider-neutral surface**: `OpenAIChat` and `AnthropicMessages` share the same public methods and return the same `LLMResponse`, so they are drop-in interchangeable.
+- **Neutral tool format with bidirectional conversion**: a single `FunctionTool` renders to either OpenAI (`to_openai_schema`) or Anthropic (`to_anthropic_schema`) and ingests from either (`from_openai_schema` / `from_anthropic_schema`). No vendor format is treated as the canonical one.
+- **Multi-turn tool calling**: `ask()` runs a bounded recursive tool-calling loop (`max_tool_rounds`), executing Python callables and feeding results back to the model.
+- **Streaming and non-streaming**: both paths are implemented for each provider; streaming yields incremental text/reasoning chunks then a final summary carrying tool calls and usage.
+- **Extended thinking**: opt-in via `thinking` (e.g. `{"type": "adaptive"}` for Anthropic); thinking text surfaces into `LLMResponse.reasoning_content`.
+- **Multimodal image input**: `build_user_message_content` attaches PIL images, rendered to each vendor's image block format.
+- **Standardized response & usage**: every call returns `LLMResponse` (success, status_code, content, tool_calls, reasoning_content, usage, raw_response) with `TokenUsage` token accounting.
+- **Compatible-gateway resilience**: the Anthropic streaming path tolerates gateways that send a non-conformant `message_start.content: null` (which crashes the SDK's high-level stream helper).
+
+## Quick Start
+
+`ark.llm` is **not** re-exported at the top level, so import from `ark.llm` directly.
+
+```python
+from ark.llm import OpenAIChat, AnthropicMessages
+
+# --- OpenAI Chat Completion compatible ---
+client = OpenAIChat(api_key="sk-...", default_model="gpt-4o-mini")
+resp = client.ask("Say pong.", stream=False)
+print(resp.content, resp.usage.total_tokens)
+
+# --- Anthropic Messages compatible (interchangeable) ---
+client = AnthropicMessages(api_key="sk-ant-...", default_model="claude-opus-4-8")
+resp = client.ask("Say pong.", stream=False)
+print(resp.content, resp.usage.total_tokens)
+```
+
+### Streaming
+
+```python
+for chunk in client.ask("Count from 1 to 5.", stream=True):
+    if chunk.content:
+        print(chunk.content, end="", flush=True)
+```
+
+### Tool calling
+
+Tools are defined once in the neutral (OpenAI-shaped) format and work with either provider.
+
+```python
+def get_weather(city: str):
+    return True, f"It is 22C and sunny in {city}."  # (is_success, content)
+
+weather_tool = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+client = AnthropicMessages(
+    api_key="sk-ant-...",
+    tools=[weather_tool],
+    tool_function_mapper={"get_weather": get_weather},
+)
+resp = client.ask("What's the weather in Paris? Use the tool.")
+print(resp.content)                       # final answer after the tool round
+print(client.latest_tool_call_result)     # {'get_weather': True}
+```
+
+### Extended thinking (Anthropic)
+
+```python
+client = AnthropicMessages(api_key="sk-ant-...", thinking={"type": "adaptive"})
+resp = client.ask("Solve 27 * 453 step by step.")
+print(resp.reasoning_content)  # thinking text
+print(resp.content)            # final answer
+```
+
+## Module Structure
+
+- `entities.py` — `LLMResponse` and `TokenUsage` dataclasses; the standardized return type for every client method.
+- `providers/base.py` — `BaseLLMClient` abstract interface (`generate`, `generate_stream`) plus `build_user_message_content` for multimodal messages.
+- `providers/openai_chat.py` — `OpenAIChat`, the OpenAI Chat Completion compatible client.
+- `providers/anthropic_messages.py` — `AnthropicMessages`, the Anthropic Messages compatible client (named after the Messages API, mirroring how `OpenAIChat` is named after the Chat Completion API).
+- `tools/base.py` — `FunctionTool`, `FunctionToolParameter`, `ToolSet`; the neutral tool representation and per-vendor schema conversion / execution.
+
+Image helpers live in `ark/core/image_service.py` (`convert_image_to_data_url` for OpenAI, `convert_image_to_base64` for Anthropic).
+
+Manual live API smoke tests (not run by pytest) live in `test/llm/live/` — copy `.env.example` to `.env`, fill in credentials, and run `python -m test.llm.live.run_live`.
+
+## Status
+
+### Done
+
+- `BaseLLMClient` abstract interface and standardized `LLMResponse` / `TokenUsage`.
+- `OpenAIChat` provider: non-streaming, streaming, multi-turn tool calling, multimodal image input, history preservation on error.
+- `AnthropicMessages` provider: non-streaming, streaming, multi-turn tool calling, multimodal image input, extended thinking, top-level `system`, mandatory `max_tokens`, and resilience to compatible gateways that send `message_start.content: null`.
+- Neutral `FunctionTool` with bidirectional OpenAI/Anthropic schema conversion and a shared execution core (`ToolSet.execute_tool_calls` / `execute_tool_calls_anthropic`).
+- Unit tests mocking each SDK (`test/llm/providers/`), plus a manual live runner (`test/llm/live/`).
+
+### Not yet done (future)
+
+- **RAG**: retrieval-augmented generation is not implemented; the `ToolSet` / `LLMResponse` entry points leave room for it.
+- **MCP**: Model Context Protocol integration is not implemented (room is left at the same tool entry points).
+- **More providers**: e.g. OpenAI Responses API (would be a separate class, not `OpenAIChat`), Gemini, etc.
+- **Structured outputs**: provider-native JSON-schema / strict-output modes are not surfaced through the neutral layer yet.
+- **Async clients**: only synchronous clients exist today.
+- **Prompt caching / batching**: vendor cost-optimization features are not exposed.
+- **Automated live tests**: the live runner is manual and human-inspected; it is not wired into pytest (would require credential-guarded opt-in).

--- a/ark/llm/README.zh-cn.md
+++ b/ark/llm/README.zh-cn.md
@@ -1,0 +1,118 @@
+# LLM 模块
+
+> For English documentation, see [README.md](./README.md)
+
+## 简介
+
+`ark.llm` 模块是一个**厂商中立**的大语言模型（LLM）客户端层。它在不同厂商 API 之上暴露一套一致的接口（`ask` / `generate` / `generate_stream`），返回标准化的 `LLMResponse`，并支持多轮工具调用、多模态图像输入、流式输出与扩展思考（extended thinking）。目前已有两个可互换的 provider：OpenAI Chat Completion 兼容（`OpenAIChat`）与 Anthropic Messages 兼容（`AnthropicMessages`）。
+
+设计目标是：**切换 provider 不需要改动调用代码**——工具以一种中立格式定义一次，按需渲染成各厂商的线上 schema；每个方法都返回同样的 `LLMResponse`。
+
+## 功能特性
+
+- **厂商中立的统一接口**：`OpenAIChat` 与 `AnthropicMessages` 共享相同的公开方法、返回相同的 `LLMResponse`，可直接互换。
+- **中立工具格式 + 双向转化**：单个 `FunctionTool` 可渲染为 OpenAI（`to_openai_schema`）或 Anthropic（`to_anthropic_schema`）格式，也可从两者摄入（`from_openai_schema` / `from_anthropic_schema`）。不把任何一家的格式当作唯一标准。
+- **多轮工具调用**：`ask()` 运行一个有上限的递归工具调用循环（`max_tool_rounds`），执行 Python 可调用对象并把结果回传给模型。
+- **流式与非流式**：每个 provider 都实现了两条路径；流式会先逐块产出文本/思考增量，最后再产出携带工具调用与用量的汇总块。
+- **扩展思考**：通过 `thinking` 开启（如 Anthropic 的 `{"type": "adaptive"}`）；思考文本会进入 `LLMResponse.reasoning_content`。
+- **多模态图像输入**：`build_user_message_content` 可附加 PIL 图像，并渲染为各厂商的图像块格式。
+- **标准化响应与用量**：每次调用都返回 `LLMResponse`（success、status_code、content、tool_calls、reasoning_content、usage、raw_response），并用 `TokenUsage` 统计 token。
+- **兼容网关健壮性**：Anthropic 流式路径能容忍发送非规范 `message_start.content: null` 的兼容网关（该字段会令 SDK 的高层流式助手崩溃）。
+
+## 快速开始
+
+`ark.llm` **不会**在顶层 `ark` 包中重新导出，请直接从 `ark.llm` 导入。
+
+```python
+from ark.llm import OpenAIChat, AnthropicMessages
+
+# --- OpenAI Chat Completion 兼容 ---
+client = OpenAIChat(api_key="sk-...", default_model="gpt-4o-mini")
+resp = client.ask("Say pong.", stream=False)
+print(resp.content, resp.usage.total_tokens)
+
+# --- Anthropic Messages 兼容（可互换）---
+client = AnthropicMessages(api_key="sk-ant-...", default_model="claude-opus-4-8")
+resp = client.ask("Say pong.", stream=False)
+print(resp.content, resp.usage.total_tokens)
+```
+
+### 流式
+
+```python
+for chunk in client.ask("Count from 1 to 5.", stream=True):
+    if chunk.content:
+        print(chunk.content, end="", flush=True)
+```
+
+### 工具调用
+
+工具以中立（OpenAI 形状）格式定义一次，对两个 provider 都适用。
+
+```python
+def get_weather(city: str):
+    return True, f"It is 22C and sunny in {city}."  # (是否成功, 内容)
+
+weather_tool = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+client = AnthropicMessages(
+    api_key="sk-ant-...",
+    tools=[weather_tool],
+    tool_function_mapper={"get_weather": get_weather},
+)
+resp = client.ask("What's the weather in Paris? Use the tool.")
+print(resp.content)                       # 工具轮之后的最终回答
+print(client.latest_tool_call_result)     # {'get_weather': True}
+```
+
+### 扩展思考（Anthropic）
+
+```python
+client = AnthropicMessages(api_key="sk-ant-...", thinking={"type": "adaptive"})
+resp = client.ask("Solve 27 * 453 step by step.")
+print(resp.reasoning_content)  # 思考文本
+print(resp.content)            # 最终回答
+```
+
+## 模块结构
+
+- `entities.py` —— `LLMResponse` 与 `TokenUsage` 数据类；每个客户端方法的标准化返回类型。
+- `providers/base.py` —— `BaseLLMClient` 抽象接口（`generate`、`generate_stream`）以及用于多模态消息的 `build_user_message_content`。
+- `providers/openai_chat.py` —— `OpenAIChat`，OpenAI Chat Completion 兼容客户端。
+- `providers/anthropic_messages.py` —— `AnthropicMessages`，Anthropic Messages 兼容客户端（按其对接的 Messages API 命名，与 `OpenAIChat` 按 Chat Completion API 命名同理）。
+- `tools/base.py` —— `FunctionTool`、`FunctionToolParameter`、`ToolSet`；中立工具表示，以及各厂商的 schema 转化 / 执行。
+
+图像辅助函数位于 `ark/core/image_service.py`（`convert_image_to_data_url` 供 OpenAI，`convert_image_to_base64` 供 Anthropic）。
+
+手动真实 API 冒烟测试（不由 pytest 收集）位于 `test/llm/live/` —— 把 `.env.example` 复制为 `.env`、填入凭据，运行 `python -m test.llm.live.run_live`。
+
+## 进度
+
+### 已完成
+
+- `BaseLLMClient` 抽象接口与标准化的 `LLMResponse` / `TokenUsage`。
+- `OpenAIChat` provider：非流式、流式、多轮工具调用、多模态图像输入、出错时保留历史。
+- `AnthropicMessages` provider：非流式、流式、多轮工具调用、多模态图像输入、扩展思考、顶层 `system`、必填 `max_tokens`，以及对发送 `message_start.content: null` 的兼容网关的健壮处理。
+- 中立 `FunctionTool`，含 OpenAI/Anthropic schema 双向转化与共享的执行核（`ToolSet.execute_tool_calls` / `execute_tool_calls_anthropic`）。
+- 对各 SDK 打桩的单元测试（`test/llm/providers/`），以及一个手动真实联调脚本（`test/llm/live/`）。
+
+### 尚未完成（以后做）
+
+- **RAG**：检索增强生成尚未实现；`ToolSet` / `LLMResponse` 出入口已为其预留空间。
+- **MCP**：Model Context Protocol 集成尚未实现（在同样的工具出入口预留了空间）。
+- **更多 provider**：例如 OpenAI Responses API（会是一个独立的类，而非 `OpenAIChat`）、Gemini 等。
+- **结构化输出**：各厂商原生的 JSON-schema / 严格输出模式尚未通过中立层暴露。
+- **异步客户端**：目前只有同步客户端。
+- **Prompt 缓存 / 批处理**：厂商的成本优化特性尚未暴露。
+- **自动化真实测试**：联调脚本是手动、人工检视的，未接入 pytest（接入需要带凭据守卫的 opt-in）。

--- a/ark/llm/README.zh-cn.md
+++ b/ark/llm/README.zh-cn.md
@@ -11,7 +11,7 @@
 ## 功能特性
 
 - **厂商中立的统一接口**：`OpenAIChat` 与 `AnthropicMessages` 共享相同的公开方法、返回相同的 `LLMResponse`，可直接互换。
-- **中立工具格式 + 双向转化**：单个 `FunctionTool` 可渲染为 OpenAI（`to_openai_schema`）或 Anthropic（`to_anthropic_schema`）格式，也可从两者摄入（`from_openai_schema` / `from_anthropic_schema`）。不把任何一家的格式当作唯一标准。
+- **中立工具格式与自动 Schema 生成**：单个 `FunctionTool` 可直接从绑定的 Python 函数的签名（Signature）和文档字符串（Docstring）中**自动提取**其 `name`、`description` 和 JSON `parameters_schema`。不把任何一家的格式当作唯一标准，各提供商的客户端在发送请求前自动将中立的 `ToolCall` 即时翻译为自身需要的格式。
 - **多轮工具调用**：`ask()` 运行一个有上限的递归工具调用循环（`max_tool_rounds`），执行 Python 可调用对象并把结果回传给模型。
 - **流式与非流式**：每个 provider 都实现了两条路径；流式会先逐块产出文本/思考增量，最后再产出携带工具调用与用量的汇总块。
 - **扩展思考**：通过 `thinking` 开启（如 Anthropic 的 `{"type": "adaptive"}`）；思考文本会进入 `LLMResponse.reasoning_content`。
@@ -47,29 +47,56 @@ for chunk in client.ask("Count from 1 to 5.", stream=True):
 
 ### 工具调用
 
-工具以中立（OpenAI 形状）格式定义一次，对两个 provider 都适用。
+工具以中立格式定义一次，对两个 provider 都适用。框架支持直接通过您的 Python 函数的签名和 docstring 自动生成 JSON schema，您也可以手动显式传入这些参数来覆盖自动生成的行为。
+
+#### 选项 A：自动生成（默认行为）
 
 ```python
-def get_weather(city: str):
+from ark.llm.tools import FunctionTool
+
+def get_weather(city: str) -> tuple[bool, str]:
+    """Get the current weather for a city.
+    
+    Args:
+        city: The name of the city.
+    """
     return True, f"It is 22C and sunny in {city}."  # (是否成功, 内容)
 
-weather_tool = {
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get the current weather for a city.",
-        "parameters": {
-            "type": "object",
-            "properties": {"city": {"type": "string"}},
-            "required": ["city"],
-        },
-    },
-}
+# 自动从 Python 函数签名和 Docstring 中提取 name、description 和 parameters_schema
+weather_tool = FunctionTool(get_weather)
+```
 
+#### 选项 B：手动显式覆盖（显式 Schema）
+
+如果您需要精确控制向大模型暴露的元数据和参数 Schema，或者希望将 JSON-Schema 与 Python 函数签名解耦，可以显式提供 `name`、`description` 和 `parameters_schema` 参数：
+
+```python
+from ark.llm.tools import FunctionTool
+
+# 手动显式覆盖元数据和 schema
+weather_tool = FunctionTool(
+    mapped_callable=get_weather,
+    name="get_weather_override",
+    description="获取指定城市的当前天气状况与温度信息。",
+    parameters_schema={
+        "type": "object",
+        "properties": {
+            "city": {
+                "type": "string",
+                "description": "目标城市名称（例如：'Paris', 'Tokyo'）"
+            }
+        },
+        "required": ["city"]
+    }
+)
+```
+
+对于上述任一选项，都可以将工具注册到客户端：
+
+```python
 client = AnthropicMessages(
     api_key="sk-ant-...",
     tools=[weather_tool],
-    tool_function_mapper={"get_weather": get_weather},
 )
 resp = client.ask("What's the weather in Paris? Use the tool.")
 print(resp.content)                       # 工具轮之后的最终回答
@@ -87,11 +114,11 @@ print(resp.content)            # 最终回答
 
 ## 模块结构
 
-- `entities.py` —— `LLMResponse` 与 `TokenUsage` 数据类；每个客户端方法的标准化返回类型。
+- `entities.py` —— `LLMResponse`、`TokenUsage` 与 `ToolCall` 数据类；用作输入和每个客户端方法的标准化返回类型。
 - `providers/base.py` —— `BaseLLMClient` 抽象接口（`generate`、`generate_stream`）以及用于多模态消息的 `build_user_message_content`。
 - `providers/openai_chat.py` —— `OpenAIChat`，OpenAI Chat Completion 兼容客户端。
 - `providers/anthropic_messages.py` —— `AnthropicMessages`，Anthropic Messages 兼容客户端（按其对接的 Messages API 命名，与 `OpenAIChat` 按 Chat Completion API 命名同理）。
-- `tools/base.py` —— `FunctionTool`、`FunctionToolParameter`、`ToolSet`；中立工具表示，以及各厂商的 schema 转化 / 执行。
+- `tools/base.py` —— `FunctionTool` 与 `ToolSet`；中立工具表示及执行引擎。
 
 图像辅助函数位于 `ark/core/image_service.py`（`convert_image_to_data_url` 供 OpenAI，`convert_image_to_base64` 供 Anthropic）。
 

--- a/ark/llm/__init__.py
+++ b/ark/llm/__init__.py
@@ -2,5 +2,13 @@
 # -*- coding: utf-8 -*-
 from ark.llm.providers import BaseLLMClient, OpenAIChat
 from ark.llm.tools import FunctionTool, FunctionToolParameter
+from ark.llm.entities import TokenUsage, LLMResponse
 
-__all__ = ["BaseLLMClient", "OpenAIChat", "FunctionTool", "FunctionToolParameter"]
+__all__ = [
+    "BaseLLMClient", 
+    "OpenAIChat", 
+    "FunctionTool", 
+    "FunctionToolParameter", 
+    "TokenUsage", 
+    "LLMResponse"
+]

--- a/ark/llm/__init__.py
+++ b/ark/llm/__init__.py
@@ -1,7 +1,7 @@
 #! python3
 # -*- coding: utf-8 -*-
 from ark.llm.providers import BaseLLMClient, OpenAIChat
-from ark.llm.tools import FunctionTool, FunctionToolParameter
+from ark.llm.tools import FunctionTool, FunctionToolParameter, ToolSet
 from ark.llm.entities import TokenUsage, LLMResponse
 
 __all__ = [
@@ -9,6 +9,7 @@ __all__ = [
     "OpenAIChat", 
     "FunctionTool", 
     "FunctionToolParameter", 
+    "ToolSet",
     "TokenUsage", 
     "LLMResponse"
 ]

--- a/ark/llm/__init__.py
+++ b/ark/llm/__init__.py
@@ -1,15 +1,16 @@
 #! python3
 # -*- coding: utf-8 -*-
-from ark.llm.providers import BaseLLMClient, OpenAIChat
+from ark.llm.providers import BaseLLMClient, OpenAIChat, AnthropicMessages
 from ark.llm.tools import FunctionTool, FunctionToolParameter, ToolSet
 from ark.llm.entities import TokenUsage, LLMResponse
 
 __all__ = [
-    "BaseLLMClient", 
-    "OpenAIChat", 
-    "FunctionTool", 
-    "FunctionToolParameter", 
+    "BaseLLMClient",
+    "OpenAIChat",
+    "AnthropicMessages",
+    "FunctionTool",
+    "FunctionToolParameter",
     "ToolSet",
-    "TokenUsage", 
+    "TokenUsage",
     "LLMResponse"
 ]

--- a/ark/llm/__init__.py
+++ b/ark/llm/__init__.py
@@ -1,0 +1,6 @@
+#! python3
+# -*- coding: utf-8 -*-
+from ark.llm.providers import BaseLLMClient, OpenAIChat
+from ark.llm.tools import FunctionTool, FunctionToolParameter
+
+__all__ = ["BaseLLMClient", "OpenAIChat", "FunctionTool", "FunctionToolParameter"]

--- a/ark/llm/__init__.py
+++ b/ark/llm/__init__.py
@@ -1,7 +1,7 @@
 #! python3
 # -*- coding: utf-8 -*-
 from ark.llm.providers import BaseLLMClient, OpenAIChat, AnthropicMessages
-from ark.llm.tools import FunctionTool, FunctionToolParameter, ToolSet
+from ark.llm.tools import FunctionTool, ToolSet
 from ark.llm.entities import TokenUsage, LLMResponse, ToolCall
 
 __all__ = [
@@ -9,7 +9,6 @@ __all__ = [
     "OpenAIChat",
     "AnthropicMessages",
     "FunctionTool",
-    "FunctionToolParameter",
     "ToolSet",
     "TokenUsage",
     "LLMResponse",

--- a/ark/llm/__init__.py
+++ b/ark/llm/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from ark.llm.providers import BaseLLMClient, OpenAIChat, AnthropicMessages
 from ark.llm.tools import FunctionTool, FunctionToolParameter, ToolSet
-from ark.llm.entities import TokenUsage, LLMResponse
+from ark.llm.entities import TokenUsage, LLMResponse, ToolCall
 
 __all__ = [
     "BaseLLMClient",
@@ -12,5 +12,6 @@ __all__ = [
     "FunctionToolParameter",
     "ToolSet",
     "TokenUsage",
-    "LLMResponse"
+    "LLMResponse",
+    "ToolCall"
 ]

--- a/ark/llm/entities.py
+++ b/ark/llm/entities.py
@@ -8,20 +8,38 @@
 @Contact:   https://github.com/SwordJack/
 """
 
-# Here put the import lib.
 from dataclasses import dataclass, field
-from typing import Any, List, Dict, Optional
+from typing import Any, Dict, List, Optional
+
 
 @dataclass
 class TokenUsage:
-    """Represents token consumption for a request."""
+    """Represents token consumption for an LLM request.
+
+    Attributes:
+        input_tokens: Number of tokens in the input prompt.
+        output_tokens: Number of tokens in the generated response.
+        total_tokens: Sum of input and output tokens.
+    """
     input_tokens: int = 0
     output_tokens: int = 0
     total_tokens: int = 0
 
+
 @dataclass
 class LLMResponse:
-    """Structured response from an LLM provider."""
+    """Structured response from an LLM provider.
+
+    Attributes:
+        success: Whether the request was successful.
+        status_code: The HTTP status code or internal error code.
+        content: The main text content of the response.
+        role: The role of the responder (usually 'assistant').
+        usage: Detailed token consumption statistics.
+        tool_calls: A list of tool calls requested by the model.
+        raw_response: The original response object from the SDK/API.
+        reasoning_content: Internal reasoning or chain-of-thought, if available.
+    """
     success: bool
     status_code: int
     content: str = ""
@@ -31,5 +49,7 @@ class LLMResponse:
     raw_response: Any = None
     reasoning_content: str = ""
 
-    def __str__(self):
-        return f"LLMResponse(success={self.success}, status={self.status_code}, content_len={len(self.content)})"
+    def __str__(self) -> str:
+        """Returns a string representation of the response summary."""
+        return (f"LLMResponse(success={self.success}, status={self.status_code}, "
+                f"content_len={len(self.content)})")

--- a/ark/llm/entities.py
+++ b/ark/llm/entities.py
@@ -1,0 +1,35 @@
+#! python3
+# -*- encoding: utf-8 -*-
+"""Core data structures for LLM responses and usage.
+
+@File   :   entities.py
+@Created:   2026/06/05 00:50
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+# Here put the import lib.
+from dataclasses import dataclass, field
+from typing import Any, List, Dict, Optional
+
+@dataclass
+class TokenUsage:
+    """Represents token consumption for a request."""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+
+@dataclass
+class LLMResponse:
+    """Structured response from an LLM provider."""
+    success: bool
+    status_code: int
+    content: str = ""
+    role: str = "assistant"
+    usage: TokenUsage = field(default_factory=TokenUsage)
+    tool_calls: List[Dict[str, Any]] = field(default_factory=list)
+    raw_response: Any = None
+    reasoning_content: str = ""
+
+    def __str__(self):
+        return f"LLMResponse(success={self.success}, status={self.status_code}, content_len={len(self.content)})"

--- a/ark/llm/entities.py
+++ b/ark/llm/entities.py
@@ -27,6 +27,20 @@ class TokenUsage:
 
 
 @dataclass
+class ToolCall:
+    """A provider-neutral representation of a tool/function call requested by the LLM.
+
+    Attributes:
+        id: The unique identifier for this tool call.
+        name: The name of the tool/function to call.
+        arguments: A JSON-serialized string of the arguments.
+    """
+    id: str
+    name: str
+    arguments: str
+
+
+@dataclass
 class LLMResponse:
     """Structured response from an LLM provider.
 
@@ -45,7 +59,7 @@ class LLMResponse:
     content: str = ""
     role: str = "assistant"
     usage: TokenUsage = field(default_factory=TokenUsage)
-    tool_calls: List[Dict[str, Any]] = field(default_factory=list)
+    tool_calls: List[ToolCall] = field(default_factory=list)
     raw_response: Any = None
     reasoning_content: str = ""
 

--- a/ark/llm/providers/__init__.py
+++ b/ark/llm/providers/__init__.py
@@ -1,6 +1,15 @@
 #! python3
-# -*- coding: utf-8 -*-
+# -*- encoding: utf-8 -*-
+"""
+@File   :   __init__.py
+@Created:   2026/06/05 00:34
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+# Here put the import lib.
 from ark.llm.providers.base import BaseLLMClient
 from ark.llm.providers.openai_chat import OpenAIChat
+from ark.llm.providers.anthropic_messages import AnthropicMessages
 
-__all__ = ["BaseLLMClient", "OpenAIChat"]
+__all__ = ["BaseLLMClient", "OpenAIChat", "AnthropicMessages"]

--- a/ark/llm/providers/__init__.py
+++ b/ark/llm/providers/__init__.py
@@ -1,0 +1,6 @@
+#! python3
+# -*- coding: utf-8 -*-
+from ark.llm.providers.base import BaseLLMClient
+from ark.llm.providers.openai_chat import OpenAIChat
+
+__all__ = ["BaseLLMClient", "OpenAIChat"]

--- a/ark/llm/providers/anthropic_messages.py
+++ b/ark/llm/providers/anthropic_messages.py
@@ -5,7 +5,7 @@
 ``AnthropicMessages`` is the concrete provider for the Anthropic Messages API
 (``/v1/messages``) and any Anthropic-compatible gateway (via ``base_url``). It
 mirrors the public surface of :class:`~ark.llm.providers.openai_chat.OpenAIChat`
-(``chat_completion`` / ``chat_completion_stream`` / ``ask`` /
+(``generate`` / ``generate_stream`` / ``ask`` /
 ``build_user_message_content``) and returns the standardized ``LLMResponse``,
 so the two providers are interchangeable.
 
@@ -37,7 +37,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 from anthropic import Anthropic, BadRequestError
 # Reuse the SDK's own streaming accumulator instead of hand-rolling block
-# reassembly; see chat_completion_stream for why we drive it ourselves.
+# reassembly; see generate_stream for why we drive it ourselves.
 from anthropic.lib.streaming._messages import accumulate_event
 from PIL import Image as PILImage
 from ark.core.image_service import convert_image_to_base64
@@ -188,7 +188,7 @@ class AnthropicMessages(BaseLLMClient):
         else:
             return self.__ask_loop(prompt, images, **kwargs)
 
-    def chat_completion(self,
+    def generate(self,
             messages: List[Dict[str, Any]],
             model: Optional[str] = None,
             max_tokens: Optional[int] = None,
@@ -201,7 +201,7 @@ class AnthropicMessages(BaseLLMClient):
 
         Top-level Anthropic parameters are passed explicitly (callers decide
         what to send) rather than auto-injected from ``self`` — this keeps the
-        method a pure atomic call, matching ``OpenAIChat.chat_completion``. The
+        method a pure atomic call, matching ``OpenAIChat.generate``. The
         ask loops supply ``system`` / ``tools`` / ``thinking`` from the client's
         configuration.
 
@@ -242,7 +242,7 @@ class AnthropicMessages(BaseLLMClient):
         except Exception as e:
             return LLMResponse(success=False, status_code=500, content=f"Error: {e}")
 
-    def chat_completion_stream(
+    def generate_stream(
             self, messages: List[Dict[str, Any]],
             model: Optional[str] = None,
             max_tokens: Optional[int] = None,
@@ -253,7 +253,7 @@ class AnthropicMessages(BaseLLMClient):
         ) -> Iterator[LLMResponse]:
         """Sends a streaming Messages request.
 
-        Top-level parameters are passed explicitly (see ``chat_completion``).
+        Top-level parameters are passed explicitly (see ``generate``).
 
         Args:
             messages: Conversation context (Anthropic message format).
@@ -269,7 +269,7 @@ class AnthropicMessages(BaseLLMClient):
             summary carrying aggregated tool calls and usage.
         """
         # Resolve client-level defaults here, at the public entry point (see
-        # chat_completion). __build_request_args assembles the rest; we stamp
+        # generate). __build_request_args assembles the rest; we stamp
         # model/max_tokens in as authoritative (overriding any stray in kwargs).
         request_args = self.__build_request_args(system, tools, thinking, **kwargs)
         request_args["model"] = model or self.default_model
@@ -366,7 +366,7 @@ class AnthropicMessages(BaseLLMClient):
             user_content = self.build_user_message_content(prompt, images)
             current_messages = self.__prepare_messages(user_content)
             # Resolve the client's configured request shape once, then pass it
-            # explicitly into each chat_completion call (parity with OpenAIChat).
+            # explicitly into each generate call (parity with OpenAIChat).
             tools_defs = (self.tool_set.get_anthropic_schema()
                           if self.tool_set else None)
             system = self.instructions or None
@@ -378,7 +378,7 @@ class AnthropicMessages(BaseLLMClient):
             round_idx = 0
             while round_idx < self.max_tool_rounds:
                 round_idx += 1
-                response = self.chat_completion(messages=current_messages,
+                response = self.generate(messages=current_messages,
                                                system=system,
                                                tools=tools_defs,
                                                thinking=self.thinking,
@@ -463,7 +463,7 @@ class AnthropicMessages(BaseLLMClient):
                 current_round_reasoning = ""
                 final_message = None
 
-                for chunk_resp in self.chat_completion_stream(
+                for chunk_resp in self.generate_stream(
                         messages=current_messages, system=system,
                         tools=tools_defs, thinking=self.thinking, **kwargs):
 
@@ -524,7 +524,7 @@ class AnthropicMessages(BaseLLMClient):
         """Assembles the optional/merged keyword arguments for a Messages call.
 
         ``model`` and ``max_tokens`` are resolved and stamped in by the public
-        entry points (``chat_completion`` / ``chat_completion_stream``), so they
+        entry points (``generate`` / ``generate_stream``), so they
         are intentionally absent here. ``system`` / ``tools`` / ``thinking`` are
         included **only when not None**: the SDK forwards an explicit ``None`` as
         ``null`` in the request body (it strips its own ``NOT_GIVEN`` sentinel,

--- a/ark/llm/providers/anthropic_messages.py
+++ b/ark/llm/providers/anthropic_messages.py
@@ -191,20 +191,43 @@ class AnthropicMessages(BaseLLMClient):
     def chat_completion(self,
             messages: List[Dict[str, Any]],
             model: Optional[str] = None,
+            max_tokens: Optional[int] = None,
+            system: Optional[str] = None,
+            tools: Optional[List[Dict[str, Any]]] = None,
+            thinking: Optional[Dict[str, Any]] = None,
             **kwargs: Any
         ) -> LLMResponse:
         """Sends a single non-streaming Messages request.
 
+        Top-level Anthropic parameters are passed explicitly (callers decide
+        what to send) rather than auto-injected from ``self`` — this keeps the
+        method a pure atomic call, matching ``OpenAIChat.chat_completion``. The
+        ask loops supply ``system`` / ``tools`` / ``thinking`` from the client's
+        configuration.
+
         Args:
             messages: Conversation context (Anthropic message format).
-            model: Specific model ID to use.
+            model: Specific model ID to use (defaults to the client default).
+            max_tokens: Max output tokens (defaults to the client default).
+            system: Top-level system instructions; omitted from the request
+                when None.
+            tools: Anthropic-format tool schemas; omitted when None.
+            thinking: Extended-thinking config; omitted when None.
             **kwargs: Extra parameters for the API.
 
         Returns:
             An LLMResponse containing the model's output.
         """
         try:
-            request_args = self.__build_request_args(model, **kwargs)
+            # Resolve client-level defaults here, at the public entry point, so
+            # a direct call (no ask loop) still gets a model and the mandatory
+            # max_tokens. __build_request_args assembles the rest; we stamp these
+            # two in as authoritative (overriding any stray copy in kwargs).
+            request_args = self.__build_request_args(
+                system, tools, thinking, **kwargs)
+            request_args["model"] = model or self.default_model
+            request_args["max_tokens"] = (
+                max_tokens if max_tokens is not None else self.max_tokens)
             message = self.client.messages.create(messages=messages,
                                                   **request_args)
             content, tool_calls, reasoning = self.__parse_content(
@@ -221,20 +244,37 @@ class AnthropicMessages(BaseLLMClient):
 
     def chat_completion_stream(
             self, messages: List[Dict[str, Any]],
-            model: Optional[str] = None, **kwargs: Any
+            model: Optional[str] = None,
+            max_tokens: Optional[int] = None,
+            system: Optional[str] = None,
+            tools: Optional[List[Dict[str, Any]]] = None,
+            thinking: Optional[Dict[str, Any]] = None,
+            **kwargs: Any
         ) -> Iterator[LLMResponse]:
         """Sends a streaming Messages request.
 
+        Top-level parameters are passed explicitly (see ``chat_completion``).
+
         Args:
             messages: Conversation context (Anthropic message format).
-            model: Specific model ID to use.
+            model: Specific model ID to use (defaults to the client default).
+            max_tokens: Max output tokens (defaults to the client default).
+            system: Top-level system instructions; omitted when None.
+            tools: Anthropic-format tool schemas; omitted when None.
+            thinking: Extended-thinking config; omitted when None.
             **kwargs: Extra parameters for the API.
 
         Yields:
             LLMResponse objects containing incremental chunks, then a final
             summary carrying aggregated tool calls and usage.
         """
-        request_args = self.__build_request_args(model, **kwargs)
+        # Resolve client-level defaults here, at the public entry point (see
+        # chat_completion). __build_request_args assembles the rest; we stamp
+        # model/max_tokens in as authoritative (overriding any stray in kwargs).
+        request_args = self.__build_request_args(system, tools, thinking, **kwargs)
+        request_args["model"] = model or self.default_model
+        request_args["max_tokens"] = (
+            max_tokens if max_tokens is not None else self.max_tokens)
 
         # We drive the RAW event iterator via ``messages.create(stream=True)``
         # rather than the SDK's high-level ``messages.stream()`` helper, but we
@@ -325,6 +365,11 @@ class AnthropicMessages(BaseLLMClient):
         try:
             user_content = self.build_user_message_content(prompt, images)
             current_messages = self.__prepare_messages(user_content)
+            # Resolve the client's configured request shape once, then pass it
+            # explicitly into each chat_completion call (parity with OpenAIChat).
+            tools_defs = (self.tool_set.get_anthropic_schema()
+                          if self.tool_set else None)
+            system = self.instructions or None
 
             total_usage = TokenUsage()
             final_content = ""
@@ -334,6 +379,9 @@ class AnthropicMessages(BaseLLMClient):
             while round_idx < self.max_tool_rounds:
                 round_idx += 1
                 response = self.chat_completion(messages=current_messages,
+                                               system=system,
+                                               tools=tools_defs,
+                                               thinking=self.thinking,
                                                **kwargs)
                 if not response.success:
                     return response
@@ -397,6 +445,11 @@ class AnthropicMessages(BaseLLMClient):
         try:
             user_content = self.build_user_message_content(prompt, images)
             current_messages = self.__prepare_messages(user_content)
+            # Resolve the client's configured request shape once, then pass it
+            # explicitly into each stream call (parity with OpenAIChat).
+            tools_defs = (self.tool_set.get_anthropic_schema()
+                          if self.tool_set else None)
+            system = self.instructions or None
 
             total_usage = TokenUsage()
             final_content = ""
@@ -411,7 +464,8 @@ class AnthropicMessages(BaseLLMClient):
                 final_message = None
 
                 for chunk_resp in self.chat_completion_stream(
-                        messages=current_messages, **kwargs):
+                        messages=current_messages, system=system,
+                        tools=tools_defs, thinking=self.thinking, **kwargs):
 
                     if chunk_resp.tool_calls:
                         tool_calls = chunk_resp.tool_calls
@@ -463,28 +517,36 @@ class AnthropicMessages(BaseLLMClient):
         except Exception as e:
             yield self.__handle_ask_exception(e)
 
-    def __build_request_args(self, model: Optional[str],
+    def __build_request_args(self, system: Optional[str] = None,
+                             tools: Optional[List[Dict[str, Any]]] = None,
+                             thinking: Optional[Dict[str, Any]] = None,
                              **kwargs: Any) -> Dict[str, Any]:
-        """Assembles the keyword arguments for a Messages API call.
+        """Assembles the optional/merged keyword arguments for a Messages call.
+
+        ``model`` and ``max_tokens`` are resolved and stamped in by the public
+        entry points (``chat_completion`` / ``chat_completion_stream``), so they
+        are intentionally absent here. ``system`` / ``tools`` / ``thinking`` are
+        included **only when not None**: the SDK forwards an explicit ``None`` as
+        ``null`` in the request body (it strips its own ``NOT_GIVEN`` sentinel,
+        not ``None``), and some compatible gateways reject a ``null`` here.
 
         Args:
-            model: Specific model ID, or None to use the default.
+            system: Top-level system instructions (omitted when None).
+            tools: Anthropic-format tool schemas (omitted when None).
+            thinking: Extended-thinking config (omitted when None).
             **kwargs: Per-call overrides merged over the client defaults.
 
         Returns:
-            A dict of API arguments (model, max_tokens, optional system/tools/
-            thinking, plus filtered defaults and overrides).
+            A dict of API arguments (without model/max_tokens, which the caller
+            stamps in afterward).
         """
-        args: Dict[str, Any] = {
-            "model": model or self.default_model,
-            "max_tokens": self.max_tokens,
-        }
-        if self.instructions:
-            args["system"] = self.instructions
-        if self.tool_set:
-            args["tools"] = self.tool_set.get_anthropic_schema()
-        if self.thinking:
-            args["thinking"] = self.thinking
+        args: Dict[str, Any] = {}
+        if system is not None:
+            args["system"] = system
+        if tools is not None:
+            args["tools"] = tools
+        if thinking is not None:
+            args["thinking"] = thinking
         args.update(self.anthropic_args_dict)
         args.update(kwargs)
         return args

--- a/ark/llm/providers/anthropic_messages.py
+++ b/ark/llm/providers/anthropic_messages.py
@@ -359,8 +359,7 @@ class AnthropicMessages(BaseLLMClient):
             current_messages = self.__prepare_messages(user_content)
             # Resolve the client's configured request shape once, then pass it
             # explicitly into each generate call (parity with OpenAIChat).
-            tools_defs = (self.tool_set.get_anthropic_schema()
-                          if self.tool_set else None)
+            tools_defs = self.__build_tools_schema()
             system = self.instructions or None
 
             total_usage = TokenUsage()
@@ -450,8 +449,7 @@ class AnthropicMessages(BaseLLMClient):
             current_messages = self.__prepare_messages(user_content)
             # Resolve the client's configured request shape once, then pass it
             # explicitly into each stream call (parity with OpenAIChat).
-            tools_defs = (self.tool_set.get_anthropic_schema()
-                          if self.tool_set else None)
+            tools_defs = self.__build_tools_schema()
             system = self.instructions or None
 
             total_usage = TokenUsage()
@@ -531,6 +529,26 @@ class AnthropicMessages(BaseLLMClient):
 
         except Exception as e:
             yield self.__handle_ask_exception(e)
+
+    def __build_tools_schema(self) -> Optional[List[Dict[str, Any]]]:
+        """Builds tool schemas in Anthropic format.
+
+        Returns:
+            A list of Anthropic-format tool schemas, or None if no tools are defined.
+        """
+        if not self.tool_set or not self.tool_set.tools:
+            return None
+        tools_defs = []
+        for t in self.tool_set.tools:
+            schema = t.parameters_schema.copy()
+            if "type" not in schema:
+                schema["type"] = "object"
+            tools_defs.append({
+                "name": t.name,
+                "description": t.description,
+                "input_schema": schema,
+            })
+        return tools_defs
 
     def __build_request_args(self, system: Optional[str] = None,
                              tools: Optional[List[Dict[str, Any]]] = None,

--- a/ark/llm/providers/anthropic_messages.py
+++ b/ark/llm/providers/anthropic_messages.py
@@ -1,0 +1,517 @@
+#! python3
+# -*- encoding: utf-8 -*-
+"""Anthropic Messages API client with structured responses and tool support.
+
+``AnthropicMessages`` is the concrete provider for the Anthropic Messages API
+(``/v1/messages``) and any Anthropic-compatible gateway (via ``base_url``). It
+mirrors the public surface of :class:`~ark.llm.providers.openai_chat.OpenAIChat`
+(``chat_completion`` / ``chat_completion_stream`` / ``ask`` /
+``build_user_message_content``) and returns the standardized ``LLMResponse``,
+so the two providers are interchangeable.
+
+The class is named after the API it targets (the *Messages* API), matching the
+convention behind ``OpenAIChat`` (the OpenAI *Chat Completion* API). Tool
+calling, and the room left for RAG / MCP, route through the same ``ToolSet`` /
+``LLMResponse`` entry points the OpenAI client uses.
+
+Key Anthropic-specific handling versus OpenAI:
+    - ``system`` is a top-level string, not a message role; ``self.messages``
+      never contains a system entry.
+    - ``max_tokens`` is mandatory.
+    - Tool results are ``tool_result`` blocks inside a ``user`` message.
+    - Tool schemas are flat ``{name, description, input_schema}``.
+    - Images are ``{"type": "image", "source": {"type": "base64", ...}}``.
+    - Extended thinking is opt-in via ``thinking`` (e.g. ``{"type": "adaptive"}``);
+      on a tool round the assistant turn echoes back the raw content blocks so
+      thinking signatures are preserved.
+
+@File   :   anthropic_messages.py
+@Created:   2026/06/06 21:13
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+from inspect import signature
+from json import dumps
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+
+from anthropic import Anthropic, BadRequestError
+from PIL import Image as PILImage
+from ark.core.image_service import convert_image_to_base64
+from ark.core.logger import LOGGER
+from ark.llm.entities import LLMResponse, TokenUsage
+from ark.llm.providers.base import BaseLLMClient
+from ark.llm.tools import FunctionTool, ToolSet
+
+
+class AnthropicMessages(BaseLLMClient):
+    """Client for the Anthropic Messages API and compatible endpoints.
+
+    Supports structured ``LLMResponse``, safe history mutation, multi-turn tool
+    calling, multimodal image input, streaming, and extended thinking.
+
+    Attributes:
+        client: The underlying Anthropic client instance.
+        default_model: The default model ID to use for requests.
+        instructions: System instructions defining the agent's behavior (sent as
+            the top-level ``system`` parameter, never as a message).
+        conversation_mode: Whether to maintain a message history.
+        max_tool_rounds: Maximum number of recursive tool-calling rounds.
+        max_tokens: The default ``max_tokens`` for requests (required by the API).
+        thinking: Optional extended-thinking config (e.g. ``{"type": "adaptive"}``).
+        messages: The current conversation history (never contains a system entry).
+        tool_set: A collection of available tools.
+        latest_tool_call_result: Results of the last tool executions.
+        anthropic_args_dict: Filtered kwargs for the Anthropic SDK.
+    """
+
+    def __init__(self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        default_model: str = "claude-opus-4-8",
+        instructions: str = "",
+        messages: List[Dict[str, Any]] = None,
+        tools: List[Dict[str, Any]] = None,
+        tool_function_mapper: Dict[str, Callable] = None,
+        tool_function_callable_kwargs: Dict[str, Any] = None,
+        conversation_mode: bool = True,
+        max_tool_rounds: int = 5,
+        max_tokens: int = 4096,
+        thinking: Optional[Dict[str, Any]] = None,
+        **kwargs: Any):
+        """Initializes an AnthropicMessages client.
+
+        Args:
+            api_key: The API key for authentication.
+            base_url: The base URL for the API endpoint (for compatible gateways).
+            default_model: The default model ID.
+            instructions: System instructions for the model (top-level ``system``).
+            messages: Initial list of conversation messages (no system entry).
+            tools: A list of tool definitions in OpenAI format (converted to
+                Anthropic format on the wire), keeping parity with OpenAIChat.
+            tool_function_mapper: Map of tool names to Python callables.
+            tool_function_callable_kwargs: Static kwargs for tool callables.
+            conversation_mode: If True, history is preserved across asks.
+            max_tool_rounds: Limits recursive tool calls per ask.
+            max_tokens: Default maximum output tokens (required by the API).
+            thinking: Optional extended-thinking config; omitted when None.
+            **kwargs: Additional arguments for the Anthropic API.
+        """
+        self.client = Anthropic(api_key=api_key, base_url=base_url)
+        self.default_model = default_model
+        self.instructions = instructions
+        self.conversation_mode = conversation_mode
+        self.max_tool_rounds = max_tool_rounds
+        self.max_tokens = max_tokens
+        self.thinking = thinking
+
+        # System lives in the top-level `system` param, so it is never stored
+        # as a message entry (unlike OpenAIChat).
+        self.messages = messages or []
+
+        # Tools are supplied in OpenAI format for parity with OpenAIChat, then
+        # rendered to Anthropic's flat schema when calling the API.
+        self.tool_set = ToolSet([
+            FunctionTool.from_openai_schema(
+                t, tool_function_mapper, tool_function_callable_kwargs)
+            for t in (tools or []) if t.get("type") == "function"
+        ])
+        self.latest_tool_call_result = {}
+
+        create_params = signature(self.client.messages.create).parameters
+        self.anthropic_args_dict = {
+            k: v for k, v in kwargs.items() if k in create_params
+        }
+
+        LOGGER.info(f"AnthropicMessages initialized (model: {default_model})")
+
+    @classmethod
+    def build_user_message_content(
+        cls, prompt: str,
+        images: Optional[List[PILImage.Image]] = None
+    ) -> Union[str, List[Dict[str, Any]]]:
+        """Builds user message content in Anthropic format.
+
+        Overrides the OpenAI-shaped base implementation to emit Anthropic
+        content blocks: a ``text`` block plus base64 ``image`` blocks.
+
+        Args:
+            prompt: The text prompt provided by the user.
+            images: An optional list of PIL Image objects to attach.
+
+        Returns:
+            A string if only text is provided, or a list of Anthropic content
+            blocks for multimodal requests.
+
+        Raises:
+            TypeError: If any item in the images list is not a PIL Image.
+        """
+        if not images:
+            return prompt
+
+        content: List[Dict[str, Any]] = [{"type": "text", "text": prompt}]
+        for img in images:
+            if not isinstance(img, PILImage.Image):
+                raise TypeError("Each image must be a PIL.Image.Image instance.")
+            media_type, image_base64 = convert_image_to_base64(img)
+            content.append({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": media_type,
+                    "data": image_base64,
+                },
+            })
+        return content
+
+    def ask(self,
+            prompt: str,
+            images: Optional[List[PILImage.Image]] = None,
+            stream: bool = False,
+            **kwargs: Any) -> Union[LLMResponse, Iterator[LLMResponse]]:
+        """Orchestrates a chat interaction, handling history and tool calls.
+
+        Args:
+            prompt (str): The user's input text.
+            images (Optional[List[PILImage.Image]]): Optional images for multimodal input.
+            stream (bool, optional): Whether to use streaming. Defaults to False.
+            **kwargs: Additional parameters for the model.
+
+        Returns:
+            An LLMResponse (non-stream) or Iterator[LLMResponse] (stream).
+        """
+        if stream:
+            return self.__ask_loop_stream(prompt, images, **kwargs)
+        else:
+            return self.__ask_loop(prompt, images, **kwargs)
+
+    def chat_completion(self,
+            messages: List[Dict[str, Any]],
+            model: Optional[str] = None,
+            **kwargs: Any
+        ) -> LLMResponse:
+        """Sends a single non-streaming Messages request.
+
+        Args:
+            messages: Conversation context (Anthropic message format).
+            model: Specific model ID to use.
+            **kwargs: Extra parameters for the API.
+
+        Returns:
+            An LLMResponse containing the model's output.
+        """
+        try:
+            request_args = self.__build_request_args(model, **kwargs)
+            message = self.client.messages.create(messages=messages,
+                                                  **request_args)
+            content, tool_calls, reasoning = self.__parse_content(
+                message.content)
+            usage = self.__extract_usage(message.usage)
+            return LLMResponse(
+                success=True, status_code=200,
+                content=content, usage=usage,
+                tool_calls=tool_calls, reasoning_content=reasoning,
+                raw_response=message
+            )
+        except Exception as e:
+            return LLMResponse(success=False, status_code=500, content=f"Error: {e}")
+
+    def chat_completion_stream(
+            self, messages: List[Dict[str, Any]],
+            model: Optional[str] = None, **kwargs: Any
+        ) -> Iterator[LLMResponse]:
+        """Sends a streaming Messages request.
+
+        Args:
+            messages: Conversation context (Anthropic message format).
+            model: Specific model ID to use.
+            **kwargs: Extra parameters for the API.
+
+        Yields:
+            LLMResponse objects containing incremental chunks, then a final
+            summary carrying aggregated tool calls and usage.
+        """
+        request_args = self.__build_request_args(model, **kwargs)
+
+        with self.client.messages.stream(messages=messages,
+                                         **request_args) as stream:
+            for event in stream:
+                if event.type != "content_block_delta":
+                    continue
+
+                delta = event.delta
+                delta_type = getattr(delta, "type", "")
+                if delta_type == "text_delta":
+                    yield LLMResponse(
+                        success=True, status_code=200,
+                        content=delta.text, raw_response=event)
+                elif delta_type == "thinking_delta":
+                    yield LLMResponse(
+                        success=True, status_code=200,
+                        content="", reasoning_content=delta.thinking,
+                        raw_response=event)
+
+            # Aggregate the full message for tool logic and usage.
+            final_message = stream.get_final_message()
+
+        _, tool_calls, _ = self.__parse_content(final_message.content)
+        usage = self.__extract_usage(final_message.usage)
+
+        # Final yield with empty content to avoid duplicating streamed text,
+        # carrying the aggregated tool calls, usage, and raw message.
+        yield LLMResponse(
+            success=True, status_code=200,
+            content="", tool_calls=tool_calls,
+            reasoning_content="", usage=usage,
+            raw_response=final_message
+        )
+
+    def __ask_loop(self,
+                  prompt: str,
+                  images: Optional[List[PILImage.Image]] = None,
+                  **kwargs: Any) -> LLMResponse:
+        """Internal loop for non-streaming interaction.
+
+        Args:
+            prompt: User prompt.
+            images: Multimodal inputs.
+            **kwargs: API arguments.
+
+        Returns:
+            Final LLMResponse after all tool calls.
+        """
+        try:
+            user_content = self.build_user_message_content(prompt, images)
+            current_messages = self.__prepare_messages(user_content)
+
+            total_usage = TokenUsage()
+            final_content = ""
+            final_reasoning = ""
+
+            round_idx = 0
+            while round_idx < self.max_tool_rounds:
+                round_idx += 1
+                response = self.chat_completion(messages=current_messages,
+                                               **kwargs)
+                if not response.success:
+                    return response
+
+                total_usage.input_tokens += response.usage.input_tokens
+                total_usage.output_tokens += response.usage.output_tokens
+                total_usage.total_tokens += response.usage.total_tokens
+                final_reasoning += response.reasoning_content
+
+                if not response.tool_calls:
+                    final_content = response.content
+                    break
+
+                # Echo the assistant turn back verbatim (raw content blocks
+                # preserve thinking signatures and tool_use blocks).
+                current_messages.append({
+                    "role": "assistant",
+                    "content": response.raw_response.content
+                })
+
+                tool_blocks, tool_results = (
+                    self.tool_set.execute_tool_calls_anthropic(
+                        response.tool_calls))
+                current_messages.append({
+                    "role": "user",
+                    "content": tool_blocks
+                })
+                self.latest_tool_call_result.update(tool_results)
+
+            if final_content:
+                current_messages.append({
+                    "role": "assistant",
+                    "content": final_content
+                })
+            if self.conversation_mode:
+                self.messages = current_messages
+
+            return LLMResponse(
+                success=True, status_code=200,
+                content=final_content, usage=total_usage,
+                reasoning_content=final_reasoning
+            )
+
+        except Exception as e:
+            return self.__handle_ask_exception(e)
+
+    def __ask_loop_stream(self,
+                         prompt: str,
+                         images: Optional[List[PILImage.Image]] = None,
+                         **kwargs: Any) -> Iterator[LLMResponse]:
+        """Internal loop for streaming interaction.
+
+        Args:
+            prompt: User prompt.
+            images: Multimodal inputs.
+            **kwargs: API arguments.
+
+        Yields:
+            Incremental chunks and a final summary per round.
+        """
+        try:
+            user_content = self.build_user_message_content(prompt, images)
+            current_messages = self.__prepare_messages(user_content)
+
+            total_usage = TokenUsage()
+            final_content = ""
+            final_reasoning = ""
+
+            round_idx = 0
+            while round_idx < self.max_tool_rounds:
+                round_idx += 1
+                tool_calls = []
+                current_round_content = ""
+                current_round_reasoning = ""
+                final_message = None
+
+                for chunk_resp in self.chat_completion_stream(
+                        messages=current_messages, **kwargs):
+
+                    if chunk_resp.tool_calls:
+                        tool_calls = chunk_resp.tool_calls
+                    if chunk_resp.usage.total_tokens > 0:
+                        total_usage.input_tokens += chunk_resp.usage.input_tokens
+                        total_usage.output_tokens += chunk_resp.usage.output_tokens
+                        total_usage.total_tokens += chunk_resp.usage.total_tokens
+                    if chunk_resp.raw_response is not None and (
+                            chunk_resp.usage.total_tokens > 0):
+                        # The final summary chunk carries the aggregated message.
+                        final_message = chunk_resp.raw_response
+
+                    if chunk_resp.content or chunk_resp.reasoning_content:
+                        current_round_content += chunk_resp.content
+                        current_round_reasoning += chunk_resp.reasoning_content
+                        yield chunk_resp
+
+                final_reasoning += current_round_reasoning
+
+                if not tool_calls:
+                    final_content = current_round_content
+                    break
+
+                # Echo the assistant turn back verbatim from the aggregated
+                # message (preserves thinking signatures and tool_use blocks).
+                current_messages.append({
+                    "role": "assistant",
+                    "content": final_message.content
+                })
+
+                tool_blocks, tool_results = (
+                    self.tool_set.execute_tool_calls_anthropic(tool_calls))
+                current_messages.append({
+                    "role": "user",
+                    "content": tool_blocks
+                })
+                self.latest_tool_call_result.update(tool_results)
+
+            if final_content:
+                current_messages.append({
+                    "role": "assistant",
+                    "content": final_content
+                })
+            if self.conversation_mode:
+                self.messages = current_messages
+
+        except Exception as e:
+            yield self.__handle_ask_exception(e)
+
+    def __build_request_args(self, model: Optional[str],
+                             **kwargs: Any) -> Dict[str, Any]:
+        """Assembles the keyword arguments for a Messages API call.
+
+        Args:
+            model: Specific model ID, or None to use the default.
+            **kwargs: Per-call overrides merged over the client defaults.
+
+        Returns:
+            A dict of API arguments (model, max_tokens, optional system/tools/
+            thinking, plus filtered defaults and overrides).
+        """
+        args: Dict[str, Any] = {
+            "model": model or self.default_model,
+            "max_tokens": self.max_tokens,
+        }
+        if self.instructions:
+            args["system"] = self.instructions
+        if self.tool_set:
+            args["tools"] = self.tool_set.get_anthropic_schema()
+        if self.thinking:
+            args["thinking"] = self.thinking
+        args.update(self.anthropic_args_dict)
+        args.update(kwargs)
+        return args
+
+    def __prepare_messages(
+            self, user_content: Union[str, List[Dict[str, Any]]]
+    ) -> List[Dict[str, Any]]:
+        """Helper to prepare the message list for ask loops.
+
+        Unlike OpenAIChat, the system prompt is never injected here; it is
+        passed via the top-level ``system`` API parameter instead.
+        """
+        messages = self.messages.copy() if self.conversation_mode else []
+        messages.append({"role": "user", "content": user_content})
+        return messages
+
+    def __parse_content(
+            self, content_blocks: List[Any]
+    ) -> Tuple[str, List[Dict[str, Any]], str]:
+        """Parses Anthropic response content blocks.
+
+        Args:
+            content_blocks: The ``content`` list from a Message response.
+
+        Returns:
+            A tuple of ``(text, tool_calls, reasoning)``, where ``tool_calls``
+            uses the standardized OpenAI shape so the shared tool machinery and
+            ``LLMResponse`` consumers work unchanged across providers.
+        """
+        text = ""
+        reasoning = ""
+        tool_calls = []
+        for block in (content_blocks or []):
+            block_type = getattr(block, "type", "")
+            if block_type == "text":
+                text += block.text
+            elif block_type == "thinking":
+                reasoning += getattr(block, "thinking", "") or ""
+            elif block_type == "tool_use":
+                tool_calls.append({
+                    "id": block.id,
+                    "type": "function",
+                    "function": {
+                        "name": block.name,
+                        "arguments": dumps(block.input or {}),
+                    },
+                })
+        return text, tool_calls, reasoning
+
+    def __extract_usage(self, usage: Any) -> TokenUsage:
+        """Extracts TokenUsage from an Anthropic usage object.
+
+        Args:
+            usage: The usage object on a Message (or None).
+
+        Returns:
+            A populated TokenUsage instance. ``total_tokens`` is computed as
+            input + output since Anthropic does not return a combined field.
+        """
+        if not usage:
+            return TokenUsage()
+        input_tokens = getattr(usage, "input_tokens", 0) or 0
+        output_tokens = getattr(usage, "output_tokens", 0) or 0
+        return TokenUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=input_tokens + output_tokens
+        )
+
+    def __handle_ask_exception(self, e: Exception) -> LLMResponse:
+        """Helper to handle exceptions in ask loops."""
+        LOGGER.error(f"ask failed: {e}")
+        status = 400 if isinstance(e, BadRequestError) else 500
+        return LLMResponse(success=False, status_code=status, content=f"Unexpected error: {e}")

--- a/ark/llm/providers/anthropic_messages.py
+++ b/ark/llm/providers/anthropic_messages.py
@@ -74,9 +74,7 @@ class AnthropicMessages(BaseLLMClient):
         default_model: str = "claude-opus-4-8",
         instructions: str = "",
         messages: List[Dict[str, Any]] = None,
-        tools: List[Dict[str, Any]] = None,
-        tool_function_mapper: Dict[str, Callable] = None,
-        tool_function_callable_kwargs: Dict[str, Any] = None,
+        tools: Union[ToolSet, List[FunctionTool], None] = None,
         conversation_mode: bool = True,
         max_tool_rounds: int = 5,
         max_tokens: int = 4096,
@@ -90,10 +88,7 @@ class AnthropicMessages(BaseLLMClient):
             default_model: The default model ID.
             instructions: System instructions for the model (top-level ``system``).
             messages: Initial list of conversation messages (no system entry).
-            tools: A list of tool definitions in OpenAI format (converted to
-                Anthropic format on the wire), keeping parity with OpenAIChat.
-            tool_function_mapper: Map of tool names to Python callables.
-            tool_function_callable_kwargs: Static kwargs for tool callables.
+            tools: An optional ToolSet or list of FunctionTool objects.
             conversation_mode: If True, history is preserved across asks.
             max_tool_rounds: Limits recursive tool calls per ask.
             max_tokens: Default maximum output tokens (required by the API).
@@ -112,13 +107,10 @@ class AnthropicMessages(BaseLLMClient):
         # as a message entry (unlike OpenAIChat).
         self.messages = messages or []
 
-        # Tools are supplied in OpenAI format for parity with OpenAIChat, then
-        # rendered to Anthropic's flat schema when calling the API.
-        self.tool_set = ToolSet([
-            FunctionTool.from_openai_schema(
-                t, tool_function_mapper, tool_function_callable_kwargs)
-            for t in (tools or []) if t.get("type") == "function"
-        ])
+        if isinstance(tools, ToolSet):
+            self.tool_set = tools
+        else:
+            self.tool_set = ToolSet(tools or [])
         self.latest_tool_call_result = {}
 
         create_params = signature(self.client.messages.create).parameters

--- a/ark/llm/providers/anthropic_messages.py
+++ b/ark/llm/providers/anthropic_messages.py
@@ -36,6 +36,9 @@ from json import dumps
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 from anthropic import Anthropic, BadRequestError
+# Reuse the SDK's own streaming accumulator instead of hand-rolling block
+# reassembly; see chat_completion_stream for why we drive it ourselves.
+from anthropic.lib.streaming._messages import accumulate_event
 from PIL import Image as PILImage
 from ark.core.image_service import convert_image_to_base64
 from ark.core.logger import LOGGER
@@ -233,37 +236,76 @@ class AnthropicMessages(BaseLLMClient):
         """
         request_args = self.__build_request_args(model, **kwargs)
 
-        with self.client.messages.stream(messages=messages,
-                                         **request_args) as stream:
-            for event in stream:
-                if event.type != "content_block_delta":
-                    continue
+        # We drive the RAW event iterator via ``messages.create(stream=True)``
+        # rather than the SDK's high-level ``messages.stream()`` helper, but we
+        # still reuse the SDK's own accumulator (``accumulate_event``) to build
+        # the final message — we do NOT hand-roll block reassembly.
+        #
+        # Why not ``messages.stream()`` directly: it seeds its snapshot from the
+        # ``message_start`` event's ``message.content``. The official API sends
+        # ``content: []`` there, but some Anthropic-*compatible* gateways send
+        # ``content: null``; the SDK then does ``snapshot.content.append(...)``
+        # on the next ``content_block_start`` and raises ``'NoneType' object has
+        # no attribute 'append'``. That crash is unreachable from the public
+        # ``messages.stream()`` API (no hook to fix the event first).
+        #
+        # We could keep ``messages.stream()`` by monkeypatching the module-level
+        # ``accumulate_event`` (the bare name it resolves at call time) to fix
+        # the field — that does work. We don't, because it mutates a third-party
+        # module attribute process-wide: every Anthropic stream in the process
+        # (other code, tests) would be rerouted through our patch. Both
+        # approaches couple to the same private ``accumulate_event``, so the
+        # patch buys nothing extra while widening the blast radius from a local
+        # call to a global override.
+        #
+        # So we take the raw events, normalize just that one offending field,
+        # and feed each event through the SDK's accumulator. Live text/thinking
+        # deltas are yielded as they arrive; the accumulated snapshot is parsed
+        # with the same ``__parse_content`` / ``__extract_usage`` the
+        # non-streaming path uses.
+        stream = self.client.messages.create(messages=messages, stream=True,
+                                             **request_args)
 
+        snapshot = None
+        for event in stream:
+            # Normalize the lone non-conformant field before the SDK accumulator
+            # sees it: a compatible gateway may send message_start.content=null.
+            if getattr(event, "type", "") == "message_start":
+                message = getattr(event, "message", None)
+                if message is not None and getattr(message, "content", None) is None:
+                    message.content = []
+
+            snapshot = accumulate_event(event=event, current_snapshot=snapshot)
+
+            # Surface incremental text / thinking to the caller as they stream.
+            if getattr(event, "type", "") == "content_block_delta":
                 delta = event.delta
-                delta_type = getattr(delta, "type", "")
-                if delta_type == "text_delta":
+                dtype = getattr(delta, "type", "")
+                if dtype == "text_delta":
                     yield LLMResponse(
                         success=True, status_code=200,
                         content=delta.text, raw_response=event)
-                elif delta_type == "thinking_delta":
+                elif dtype == "thinking_delta":
                     yield LLMResponse(
                         success=True, status_code=200,
                         content="", reasoning_content=delta.thinking,
                         raw_response=event)
 
-            # Aggregate the full message for tool logic and usage.
-            final_message = stream.get_final_message()
+        # Parse the SDK-accumulated snapshot with the shared (non-streaming)
+        # helpers — tool_use inputs were reassembled from partial_json by the
+        # accumulator, so there is nothing bespoke to rebuild here.
+        _, tool_calls, _ = self.__parse_content(snapshot.content if snapshot else [])
+        usage = self.__extract_usage(snapshot.usage if snapshot else None)
 
-        _, tool_calls, _ = self.__parse_content(final_message.content)
-        usage = self.__extract_usage(final_message.usage)
-
-        # Final yield with empty content to avoid duplicating streamed text,
-        # carrying the aggregated tool calls, usage, and raw message.
+        # Final yield: empty content (text already streamed) carrying aggregated
+        # tool calls + usage. ``raw_response`` is the accumulated Message snapshot
+        # so __ask_loop_stream can echo the assistant turn verbatim on a tool
+        # round (its content blocks preserve thinking signatures and tool_use).
         yield LLMResponse(
             success=True, status_code=200,
             content="", tool_calls=tool_calls,
             reasoning_content="", usage=usage,
-            raw_response=final_message
+            raw_response=snapshot
         )
 
     def __ask_loop(self,
@@ -377,9 +419,10 @@ class AnthropicMessages(BaseLLMClient):
                         total_usage.input_tokens += chunk_resp.usage.input_tokens
                         total_usage.output_tokens += chunk_resp.usage.output_tokens
                         total_usage.total_tokens += chunk_resp.usage.total_tokens
-                    if chunk_resp.raw_response is not None and (
-                            chunk_resp.usage.total_tokens > 0):
-                        # The final summary chunk carries the aggregated message.
+                    # The final summary chunk carries the SDK-accumulated Message
+                    # snapshot in raw_response (delta chunks carry a stream event,
+                    # which has no `.content`); detect it by that attribute.
+                    if hasattr(chunk_resp.raw_response, "content"):
                         final_message = chunk_resp.raw_response
 
                     if chunk_resp.content or chunk_resp.reasoning_content:
@@ -393,8 +436,9 @@ class AnthropicMessages(BaseLLMClient):
                     final_content = current_round_content
                     break
 
-                # Echo the assistant turn back verbatim from the aggregated
-                # message (preserves thinking signatures and tool_use blocks).
+                # Echo the assistant turn back verbatim from the accumulated
+                # snapshot (its content blocks preserve thinking signatures and
+                # tool_use blocks the API requires on the next round).
                 current_messages.append({
                     "role": "assistant",
                     "content": final_message.content

--- a/ark/llm/providers/anthropic_messages.py
+++ b/ark/llm/providers/anthropic_messages.py
@@ -42,7 +42,7 @@ from anthropic.lib.streaming._messages import accumulate_event
 from PIL import Image as PILImage
 from ark.core.image_service import convert_image_to_base64
 from ark.core.logger import LOGGER
-from ark.llm.entities import LLMResponse, TokenUsage
+from ark.llm.entities import LLMResponse, TokenUsage, ToolCall
 from ark.llm.providers.base import BaseLLMClient
 from ark.llm.tools import FunctionTool, ToolSet
 
@@ -402,9 +402,20 @@ class AnthropicMessages(BaseLLMClient):
                     "content": response.raw_response.content
                 })
 
-                tool_blocks, tool_results = (
-                    self.tool_set.execute_tool_calls_anthropic(
-                        response.tool_calls))
+                tool_outputs, tool_results = self.tool_set.execute_tool_calls(
+                    response.tool_calls)
+
+                tool_blocks = []
+                for tc, output, is_success in zip(response.tool_calls, tool_outputs, tool_results.values()):
+                    block: Dict[str, Any] = {
+                        "type": "tool_result",
+                        "tool_use_id": tc.id,
+                        "content": str(output),
+                    }
+                    if not is_success:
+                        block["is_error"] = True
+                    tool_blocks.append(block)
+
                 current_messages.append({
                     "role": "user",
                     "content": tool_blocks
@@ -498,8 +509,20 @@ class AnthropicMessages(BaseLLMClient):
                     "content": final_message.content
                 })
 
-                tool_blocks, tool_results = (
-                    self.tool_set.execute_tool_calls_anthropic(tool_calls))
+                tool_outputs, tool_results = self.tool_set.execute_tool_calls(
+                    tool_calls)
+
+                tool_blocks = []
+                for tc, output, is_success in zip(tool_calls, tool_outputs, tool_results.values()):
+                    block: Dict[str, Any] = {
+                        "type": "tool_result",
+                        "tool_use_id": tc.id,
+                        "content": str(output),
+                    }
+                    if not is_success:
+                        block["is_error"] = True
+                    tool_blocks.append(block)
+
                 current_messages.append({
                     "role": "user",
                     "content": tool_blocks
@@ -565,7 +588,7 @@ class AnthropicMessages(BaseLLMClient):
 
     def __parse_content(
             self, content_blocks: List[Any]
-    ) -> Tuple[str, List[Dict[str, Any]], str]:
+    ) -> Tuple[str, List[ToolCall], str]:
         """Parses Anthropic response content blocks.
 
         Args:
@@ -573,8 +596,7 @@ class AnthropicMessages(BaseLLMClient):
 
         Returns:
             A tuple of ``(text, tool_calls, reasoning)``, where ``tool_calls``
-            uses the standardized OpenAI shape so the shared tool machinery and
-            ``LLMResponse`` consumers work unchanged across providers.
+            is a list of standardized ToolCall instances.
         """
         text = ""
         reasoning = ""
@@ -586,14 +608,13 @@ class AnthropicMessages(BaseLLMClient):
             elif block_type == "thinking":
                 reasoning += getattr(block, "thinking", "") or ""
             elif block_type == "tool_use":
-                tool_calls.append({
-                    "id": block.id,
-                    "type": "function",
-                    "function": {
-                        "name": block.name,
-                        "arguments": dumps(block.input or {}),
-                    },
-                })
+                tool_calls.append(
+                    ToolCall(
+                        id=block.id,
+                        name=block.name,
+                        arguments=dumps(block.input or {})
+                    )
+                )
         return text, tool_calls, reasoning
 
     def __extract_usage(self, usage: Any) -> TokenUsage:

--- a/ark/llm/providers/base.py
+++ b/ark/llm/providers/base.py
@@ -9,31 +9,69 @@
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, List, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
+
+from PIL import Image as PILImage
+
+from ark.core.image_service import convert_image_to_data_url
 from ark.llm.entities import LLMResponse
 
+
 class BaseLLMClient(ABC):
-    """
-    Abstract base class for all LLM provider clients.
+    """Abstract base class for all LLM provider clients.
+
     Ensures a consistent interface for interacting with various LLM APIs.
     """
 
     @abstractmethod
-    def chat_completion(
-        self, 
-        messages: List[Dict[str, str]], 
-        model: Optional[str] = None,
-        **kwargs: Any
-    ) -> LLMResponse:
-        """
-        Sends a chat completion request to the LLM provider.
+    def chat_completion(self,
+                        messages: List[Dict[str, str]],
+                        model: Optional[str] = None,
+                        **kwargs: Any) -> LLMResponse:
+        """Sends a chat completion request to the LLM provider.
 
         Args:
-            messages (List[Dict[str, str]]): A list of message objects.
-            model (Optional[str]): The model to use.
-            **kwargs: Additional parameters.
+            messages: A list of message objects representing the conversation.
+            model: The specific model ID to use for this request.
+            **kwargs: Additional provider-specific parameters.
 
         Returns:
-            LLMResponse: Structured response object.
+            An LLMResponse object containing the structured result.
         """
         pass
+
+    @staticmethod
+    def build_user_message_content(
+        prompt: str,
+        images: Optional[List[PILImage.Image]] = None
+    ) -> Union[str, List[Dict[str, Any]]]:
+        """Builds user message content, supporting multimodal input.
+
+        Standardizes the input into an OpenAI-compatible format if images
+        are provided.
+
+        Args:
+            prompt: The text prompt provided by the user.
+            images: An optional list of PIL Image objects to attach.
+
+        Returns:
+            A string if only text is provided, or a list of content dictionaries
+            for multimodal requests.
+
+        Raises:
+            TypeError: If any item in the images list is not a PIL Image.
+        """
+        if not images:
+            return prompt
+
+        content = [{"type": "text", "text": prompt}]
+        for img in images:
+            if not isinstance(img, PILImage.Image):
+                raise TypeError("Each image must be a PIL.Image.Image instance.")
+            content.append({
+                "type": "image_url",
+                "image_url": {
+                    "url": convert_image_to_data_url(img)
+                },
+            })
+        return content

--- a/ark/llm/providers/base.py
+++ b/ark/llm/providers/base.py
@@ -8,9 +8,9 @@
 @Contact:   https://github.com/SwordJack/
 """
 
-# Here put the import lib.
 from abc import ABC, abstractmethod
 from typing import Any, List, Dict, Optional
+from ark.llm.entities import LLMResponse
 
 class BaseLLMClient(ABC):
     """
@@ -24,16 +24,16 @@ class BaseLLMClient(ABC):
         messages: List[Dict[str, str]], 
         model: Optional[str] = None,
         **kwargs: Any
-    ) -> Any:
+    ) -> LLMResponse:
         """
         Sends a chat completion request to the LLM provider.
 
         Args:
-            messages (List[Dict[str, str]]): A list of message objects representing the conversation history.
-            model (Optional[str]): The model to use for completion.
-            **kwargs: Additional provider-specific parameters (e.g., temperature, max_tokens).
+            messages (List[Dict[str, str]]): A list of message objects.
+            model (Optional[str]): The model to use.
+            **kwargs: Additional parameters.
 
         Returns:
-            Any: The response from the LLM provider.
+            LLMResponse: Structured response object.
         """
         pass

--- a/ark/llm/providers/base.py
+++ b/ark/llm/providers/base.py
@@ -9,7 +9,7 @@
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 from PIL import Image as PILImage
 
@@ -28,7 +28,7 @@ class BaseLLMClient(ABC):
                         messages: List[Dict[str, str]],
                         model: Optional[str] = None,
                         **kwargs: Any) -> LLMResponse:
-        """Sends a chat completion request to the LLM provider.
+        """Sends a non-streaming chat completion request.
 
         Args:
             messages: A list of message objects representing the conversation.
@@ -40,9 +40,26 @@ class BaseLLMClient(ABC):
         """
         pass
 
-    @staticmethod
+    @abstractmethod
+    def chat_completion_stream(self,
+                               messages: List[Dict[str, str]],
+                               model: Optional[str] = None,
+                               **kwargs: Any) -> Iterator[LLMResponse]:
+        """Sends a streaming chat completion request.
+
+        Args:
+            messages: A list of message objects representing the conversation.
+            model: The specific model ID to use for this request.
+            **kwargs: Additional provider-specific parameters.
+
+        Yields:
+            LLMResponse objects containing incremental content chunks.
+        """
+        pass
+
+    @classmethod
     def build_user_message_content(
-        prompt: str,
+        cls, prompt: str,
         images: Optional[List[PILImage.Image]] = None
     ) -> Union[str, List[Dict[str, Any]]]:
         """Builds user message content, supporting multimodal input.

--- a/ark/llm/providers/base.py
+++ b/ark/llm/providers/base.py
@@ -1,0 +1,39 @@
+#! python3
+# -*- encoding: utf-8 -*-
+"""Abstract base class for LLM providers.
+
+@File   :   base.py
+@Created:   2026/06/05 00:34
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+# Here put the import lib.
+from abc import ABC, abstractmethod
+from typing import Any, List, Dict, Optional
+
+class BaseLLMClient(ABC):
+    """
+    Abstract base class for all LLM provider clients.
+    Ensures a consistent interface for interacting with various LLM APIs.
+    """
+
+    @abstractmethod
+    def chat_completion(
+        self, 
+        messages: List[Dict[str, str]], 
+        model: Optional[str] = None,
+        **kwargs: Any
+    ) -> Any:
+        """
+        Sends a chat completion request to the LLM provider.
+
+        Args:
+            messages (List[Dict[str, str]]): A list of message objects representing the conversation history.
+            model (Optional[str]): The model to use for completion.
+            **kwargs: Additional provider-specific parameters (e.g., temperature, max_tokens).
+
+        Returns:
+            Any: The response from the LLM provider.
+        """
+        pass

--- a/ark/llm/providers/base.py
+++ b/ark/llm/providers/base.py
@@ -24,11 +24,11 @@ class BaseLLMClient(ABC):
     """
 
     @abstractmethod
-    def chat_completion(self,
-                        messages: List[Dict[str, str]],
-                        model: Optional[str] = None,
-                        **kwargs: Any) -> LLMResponse:
-        """Sends a non-streaming chat completion request.
+    def generate(self,
+                 messages: List[Dict[str, str]],
+                 model: Optional[str] = None,
+                 **kwargs: Any) -> LLMResponse:
+        """Sends a non-streaming generation request.
 
         Args:
             messages: A list of message objects representing the conversation.
@@ -41,11 +41,11 @@ class BaseLLMClient(ABC):
         pass
 
     @abstractmethod
-    def chat_completion_stream(self,
-                               messages: List[Dict[str, str]],
-                               model: Optional[str] = None,
-                               **kwargs: Any) -> Iterator[LLMResponse]:
-        """Sends a streaming chat completion request.
+    def generate_stream(self,
+                        messages: List[Dict[str, str]],
+                        model: Optional[str] = None,
+                        **kwargs: Any) -> Iterator[LLMResponse]:
+        """Sends a streaming generation request.
 
         Args:
             messages: A list of message objects representing the conversation.

--- a/ark/llm/providers/openai_chat.py
+++ b/ark/llm/providers/openai_chat.py
@@ -1,6 +1,6 @@
 #! python3
 # -*- encoding: utf-8 -*-
-"""OpenAI Chat Completion compatible interface with tool calling and history support.
+"""OpenAI Chat Completion client with structured responses and multi-turn tool support.
 
 @File   :   openai_chat.py
 @Created:   2026/06/05 00:34
@@ -11,7 +11,8 @@
 # Here put the import lib.
 
 from typing import Any, List, Dict, Optional, Union, Tuple, Callable
-from json import loads
+import json
+import re
 from inspect import signature
 from PIL import Image as PILImage
 
@@ -26,13 +27,15 @@ from openai import (
 )
 
 from ark.llm.providers.base import BaseLLMClient
+from ark.llm.entities import LLMResponse, TokenUsage
 from ark.llm.tools import FunctionTool
 from ark.core.logger import LOGGER
 from ark.core.image_service import convert_image_to_data_url
 
 class OpenAIChat(BaseLLMClient):
     """
-    Client for OpenAI Chat Completion compatible APIs, supporting history and tools.
+    Optimized client for OpenAI Chat Completion compatible APIs.
+    Supports structured LLMResponse, safe history mutation, and multi-turn tool calling.
     """
 
     def __init__(
@@ -46,226 +49,170 @@ class OpenAIChat(BaseLLMClient):
         tool_function_mapper: Dict[str, Callable] = None,
         tool_function_callable_kwargs: Dict[str, Any] = None,
         conversation_mode: bool = True,
+        max_tool_rounds: int = 5,
         **kwargs: Any
     ):
-        """
-        Initializes the OpenAI Chat client.
-
-        Args:
-            api_key: API key for authentication.
-            base_url: Base URL for the API.
-            default_model: Default model to use.
-            instructions: System instructions to define the agent behavior.
-            messages: Initial conversation history.
-            tools: List of OpenAI-style tool definitions.
-            tool_function_mapper: Map of tool names to Python callables.
-            tool_function_callable_kwargs: Additional kwargs for tool callables.
-            conversation_mode: If True, retains conversation history.
-            **kwargs: Additional parameters for the OpenAI client and chat completions.
-        """
         self.client = OpenAI(api_key=api_key, base_url=base_url)
         self.default_model = default_model
         self.instructions = instructions
         self.conversation_mode = conversation_mode
+        self.max_tool_rounds = max_tool_rounds
         
-        # Initialize messages
-        if messages:
-            self.messages = messages
-        elif self.instructions:
+        self.messages = messages or []
+        if not self.messages and self.instructions:
             self.messages = [{"role": "system", "content": self.instructions}]
-        else:
-            self.messages = []
 
-        # Initialize tools
-        tools = tools or []
-        tool_function_mapper = tool_function_mapper or {}
-        tool_function_callable_kwargs = tool_function_callable_kwargs or {}
-        
         self.function_tools = [
-            FunctionTool(
-                tool_definition_dict=t, 
-                tool_function_mapper=tool_function_mapper,
-                tool_function_callable_kwargs=tool_function_callable_kwargs
-            ) for t in tools if t.get("type") == "function"
+            FunctionTool(t, tool_function_mapper, tool_function_callable_kwargs)
+            for t in (tools or []) if t.get("type") == "function"
         ]
         self.latest_tool_call_result = {}
 
-        # Filter kwargs for chat completion
         create_params = signature(self.client.chat.completions.create).parameters
         self.openai_args_dict = {k: v for k, v in kwargs.items() if k in create_params}
 
-        LOGGER.info(f"Initialized OpenAIChat (model: {default_model}, conversation_mode: {conversation_mode})")
+        LOGGER.info(f"OpenAIChat initialized (model: {default_model})")
 
     @staticmethod
-    def build_user_message_content(
-        prompt: str,
-        images: Optional[List[PILImage.Image]] = None,
-    ) -> Union[str, List[Dict[str, Any]]]:
-        """Builds message content, supporting multimodal input if images are provided."""
+    def build_user_message_content(prompt: str, images: Optional[List[PILImage.Image]] = None) -> Union[str, List[Dict[str, Any]]]:
         if not images:
             return prompt
-
         content = [{"type": "text", "text": prompt}]
         for img in images:
             if not isinstance(img, PILImage.Image):
-                raise TypeError("Each image must be a PIL.Image.Image instance.")
-            content.append({
-                "type": "image_url",
-                "image_url": {"url": convert_image_to_data_url(img)},
-            })
+                raise TypeError("Images must be PIL instances.")
+            content.append({"type": "image_url", "image_url": {"url": convert_image_to_data_url(img)}})
         return content
 
-    def chat_completion(
-        self, 
-        messages: List[Dict[str, str]], 
-        model: Optional[str] = None,
-        **kwargs: Any
-    ) -> Any:
-        """Low-level call to OpenAI API."""
-        target_model = model or self.default_model
-        merged_kwargs = {**self.openai_args_dict, **kwargs}
-        return self.client.chat.completions.create(
-            model=target_model,
-            messages=messages,
-            **merged_kwargs
+    def _extract_usage(self, usage: Any) -> TokenUsage:
+        if not usage: return TokenUsage()
+        return TokenUsage(
+            input_tokens=getattr(usage, "prompt_tokens", 0),
+            output_tokens=getattr(usage, "completion_tokens", 0),
+            total_tokens=getattr(usage, "total_tokens", 0)
         )
 
-    def ask(
-        self, 
-        prompt: str, 
-        images: Optional[List[PILImage.Image]] = None,
-        stream: bool = True,
-        **kwargs: Any
-    ) -> Tuple[bool, int, str]:
-        """
-        High-level interface for chat, handling history, tools, and streaming.
+    def _parse_completion(self, completion: Any) -> Tuple[str, List[Dict[str, Any]], str, TokenUsage]:
+        choice = completion.choices[0]
+        content = choice.message.content or ""
+        tool_calls = []
+        if choice.message.tool_calls:
+            tool_calls = [
+                {"id": tc.id, "type": "function", "function": {"name": tc.function.name, "arguments": tc.function.arguments}}
+                for tc in choice.message.tool_calls
+            ]
+        reasoning = getattr(choice.message, "reasoning_content", "")
+        usage = self._extract_usage(completion.usage)
+        return content, tool_calls, reasoning, usage
 
-        Returns:
-            Tuple[bool, int, str]: (is_success, status_code, content)
-        """
+    def _parse_stream(self, stream: Any) -> Tuple[str, List[Dict[str, Any]], str, TokenUsage]:
+        content = ""
+        tool_calls = []
+        reasoning = ""
+        usage = TokenUsage()
+        
+        for chunk in stream:
+            if chunk.usage:
+                usage = self._extract_usage(chunk.usage)
+            if not chunk.choices: continue
+            delta = chunk.choices[0].delta
+            if delta.content: content += delta.content
+            if hasattr(delta, "reasoning_content") and delta.reasoning_content:
+                reasoning += delta.reasoning_content
+            if delta.tool_calls:
+                for tc_chunk in delta.tool_calls:
+                    while len(tool_calls) <= tc_chunk.index:
+                        tool_calls.append({"id": "", "type": "function", "function": {"name": "", "arguments": ""}})
+                    tc = tool_calls[tc_chunk.index]
+                    if tc_chunk.id: tc["id"] = tc_chunk.id
+                    if tc_chunk.function:
+                        if tc_chunk.function.name: tc["function"]["name"] = tc_chunk.function.name
+                        if tc_chunk.function.arguments: tc["function"]["arguments"] += tc_chunk.function.arguments
+        return content, tool_calls, reasoning, usage
+
+    def chat_completion(self, messages: List[Dict[str, str]], model: Optional[str] = None, **kwargs: Any) -> LLMResponse:
+        try:
+            target_model = model or self.default_model
+            args = {**self.openai_args_dict, **kwargs}
+            completion = self.client.chat.completions.create(model=target_model, messages=messages, **args)
+            content, tool_calls, reasoning, usage = self._parse_completion(completion)
+            return LLMResponse(True, 200, content, usage=usage, tool_calls=tool_calls, reasoning_content=reasoning, raw_response=completion)
+        except Exception as e:
+            return LLMResponse(False, 500, f"Error: {e}")
+
+    def ask(self, prompt: str, images: Optional[List[PILImage.Image]] = None, stream: bool = True, **kwargs: Any) -> LLMResponse:
         try:
             user_content = self.build_user_message_content(prompt, images)
             
-            # Manage message history
-            if self.conversation_mode:
-                messages = self.messages.copy()
-            else:
-                messages = []
-                if self.instructions:
-                    messages.append({"role": "system", "content": self.instructions})
+            # Use local messages to prevent state pollution on error
+            current_messages = self.messages.copy() if self.conversation_mode else []
+            if not current_messages and self.instructions:
+                current_messages.append({"role": "system", "content": self.instructions})
+            current_messages.append({"role": "user", "content": user_content})
+
+            tools_defs = [t.tool_definition_dict for t in self.function_tools] if self.function_tools else None
             
-            messages.append({"role": "user", "content": user_content})
-
-            tools_definitions = [t.tool_definition_dict for t in self.function_tools] if self.function_tools else None
-
-            # First Call
-            response_content = ""
-            current_tool_calls = []
+            final_content = ""
+            final_reasoning = ""
+            total_usage = TokenUsage()
             
-            completion_args = {
-                "messages": messages,
-                "model": self.default_model,
-                "tools": tools_definitions,
-                "stream": stream,
-                **self.openai_args_dict,
-                **kwargs
-            }
-
-            if stream:
-                response = self.client.chat.completions.create(**completion_args)
-                for chunk in response:
-                    if not chunk.choices: continue
-                    delta = chunk.choices[0].delta
-                    if delta.content:
-                        response_content += delta.content
-                    if delta.tool_calls:
-                        for tc_chunk in delta.tool_calls:
-                            while len(current_tool_calls) <= tc_chunk.index:
-                                current_tool_calls.append({"id": "", "type": "function", "function": {"name": "", "arguments": ""}})
-                            tc = current_tool_calls[tc_chunk.index]
-                            if tc_chunk.id: tc["id"] = tc_chunk.id
-                            if tc_chunk.function:
-                                if tc_chunk.function.name: tc["function"]["name"] = tc_chunk.function.name
-                                if tc_chunk.function.arguments: tc["function"]["arguments"] += tc_chunk.function.arguments
-            else:
-                response = self.client.chat.completions.create(**completion_args)
-                msg = response.choices[0].message
-                response_content = msg.content or ""
-                if msg.tool_calls:
-                    current_tool_calls = [
-                        {"id": tc.id, "type": "function", "function": {"name": tc.function.name, "arguments": tc.function.arguments}}
-                        for tc in msg.tool_calls
-                    ]
-
-            # Handle Tool Calls
-            if current_tool_calls:
-                messages.append({"role": "assistant", "tool_calls": current_tool_calls})
+            round_idx = 0
+            while round_idx < self.max_tool_rounds:
+                round_idx += 1
+                completion_args = {
+                    "messages": current_messages,
+                    "model": self.default_model,
+                    "tools": tools_defs,
+                    "stream": stream,
+                    **self.openai_args_dict,
+                    **kwargs
+                }
                 
-                for tc in current_tool_calls:
+                response = self.client.chat.completions.create(**completion_args)
+                if stream:
+                    content, tool_calls, reasoning, usage = self._parse_stream(response)
+                else:
+                    content, tool_calls, reasoning, usage = self._parse_completion(response)
+                
+                final_content = content
+                final_reasoning += reasoning
+                total_usage.input_tokens += usage.input_tokens
+                total_usage.output_tokens += usage.output_tokens
+                total_usage.total_tokens += usage.total_tokens
+
+                if not tool_calls:
+                    # Final response obtained
+                    break
+
+                # Handle Tool Calls
+                assistant_msg = {"role": "assistant", "tool_calls": tool_calls}
+                if content: assistant_msg["content"] = content
+                current_messages.append(assistant_msg)
+                
+                for tc in tool_calls:
                     func_name = tc["function"]["name"]
                     tool = next((t for t in self.function_tools if t.name == func_name), None)
-                    
                     if tool:
                         result = tool.execute(tc["function"]["arguments"])
-                        # Logic from legacy: result might be (is_success, value)
-                        if isinstance(result, tuple) and len(result) == 2:
-                            is_success, tool_output = result
-                        else:
-                            is_success, tool_output = True, str(result)
-                        
-                        self.latest_tool_call_result[func_name] = is_success
+                        tool_output = str(result[1] if isinstance(result, tuple) else result)
+                        self.latest_tool_call_result[func_name] = result[0] if isinstance(result, tuple) else True
                     else:
                         tool_output = f"Tool '{func_name}' not found."
                         self.latest_tool_call_result[func_name] = False
                     
-                    messages.append({
-                        "tool_call_id": tc["id"],
-                        "role": "tool",
-                        "name": func_name,
-                        "content": str(tool_output)
-                    })
+                    current_messages.append({"tool_call_id": tc["id"], "role": "tool", "name": func_name, "content": tool_output})
 
-                # Second Call after tools
-                second_response = self.client.chat.completions.create(
-                    messages=messages,
-                    model=self.default_model,
-                    tools=tools_definitions,
-                    stream=stream,
-                    **self.openai_args_dict,
-                    **kwargs
-                )
-                
-                final_content = ""
-                if stream:
-                    for chunk in second_response:
-                        if chunk.choices[0].delta.content:
-                            final_content += chunk.choices[0].delta.content
-                else:
-                    final_content = second_response.choices[0].message.content or ""
-                
-                response_content = final_content
-
-            # Update History
-            if response_content:
-                messages.append({"role": "assistant", "content": response_content})
+            # Loop finished or max rounds reached
+            if final_content:
+                current_messages.append({"role": "assistant", "content": final_content})
             
+            # Commit changes to self.messages only on success
             if self.conversation_mode:
-                self.messages = messages
+                self.messages = current_messages
 
-            return True, 200, response_content
+            return LLMResponse(True, 200, final_content, usage=total_usage, reasoning_content=final_reasoning)
 
-        except RateLimitError:
-            return True, 429, "Rate Limit Error"
-        except BadRequestError as e:
-            return True, 400, f"Bad Request: {e}"
-        except APITimeoutError:
-            return False, 500, "API Timeout"
-        except AuthenticationError:
-            return False, 401, "Authentication Failed"
-        except InternalServerError:
-            return False, 500, "Internal Server Error"
-        except APIError as e:
-            return False, 500, f"API Error: {e}"
         except Exception as e:
-            LOGGER.error(f"Unexpected error: {e}")
-            return False, 500, f"Unexpected error: {e}"
+            LOGGER.error(f"ask failed: {e}")
+            status = 400 if isinstance(e, BadRequestError) else 500
+            return LLMResponse(False, status, f"Unexpected error: {e}")

--- a/ark/llm/providers/openai_chat.py
+++ b/ark/llm/providers/openai_chat.py
@@ -8,154 +8,249 @@
 @Contact:   https://github.com/SwordJack/
 """
 
-# Here put the import lib.
-
-from typing import Any, List, Dict, Optional, Union, Tuple, Callable
-import json
-import re
 from inspect import signature
-from PIL import Image as PILImage
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from openai import (
-    OpenAI,
-    APIError,
-    RateLimitError,
     BadRequestError,
-    APITimeoutError,
-    AuthenticationError,
-    InternalServerError,
+    OpenAI,
 )
+from PIL import Image as PILImage
 
-from ark.llm.providers.base import BaseLLMClient
-from ark.llm.entities import LLMResponse, TokenUsage
-from ark.llm.tools import FunctionTool
 from ark.core.logger import LOGGER
-from ark.core.image_service import convert_image_to_data_url
+from ark.llm.entities import LLMResponse, TokenUsage
+from ark.llm.providers.base import BaseLLMClient
+from ark.llm.tools import FunctionTool, ToolSet
+
 
 class OpenAIChat(BaseLLMClient):
-    """
-    Optimized client for OpenAI Chat Completion compatible APIs.
-    Supports structured LLMResponse, safe history mutation, and multi-turn tool calling.
+    """Optimized client for OpenAI Chat Completion compatible APIs.
+
+    Supports structured LLMResponse, safe history mutation, and multi-turn
+    tool calling.
+
+    Attributes:
+        client: The underlying OpenAI client instance.
+        default_model: The default model ID to use for requests.
+        instructions: System instructions defining the agent's behavior.
+        conversation_mode: Whether to maintain a message history.
+        max_tool_rounds: Maximum number of recursive tool-calling rounds.
+        messages: The current conversation history.
+        tool_set: A collection of available tools.
+        latest_tool_call_result: results of the last tool executions.
+        openai_args_dict: Filtered kwargs for the OpenAI SDK.
     """
 
-    def __init__(
-        self, 
-        api_key: Optional[str] = None, 
-        base_url: Optional[str] = None,
-        default_model: str = "gpt-3.5-turbo",
-        instructions: str = "",
-        messages: List[Dict[str, str]] = None,
-        tools: List[Dict[str, Any]] = None,
-        tool_function_mapper: Dict[str, Callable] = None,
-        tool_function_callable_kwargs: Dict[str, Any] = None,
-        conversation_mode: bool = True,
-        max_tool_rounds: int = 5,
-        **kwargs: Any
-    ):
+    def __init__(self,
+                 api_key: Optional[str] = None,
+                 base_url: Optional[str] = None,
+                 default_model: str = "gpt-3.5-turbo",
+                 instructions: str = "",
+                 messages: List[Dict[str, str]] = None,
+                 tools: List[Dict[str, Any]] = None,
+                 tool_function_mapper: Dict[str, Callable] = None,
+                 tool_function_callable_kwargs: Dict[str, Any] = None,
+                 conversation_mode: bool = True,
+                 max_tool_rounds: int = 5,
+                 **kwargs: Any):
+        """Initializes an OpenAIChat client.
+
+        Args:
+            api_key: The API key for authentication.
+            base_url: The base URL for the API endpoint.
+            default_model: The default model ID.
+            instructions: System instructions for the model.
+            messages: Initial list of conversation messages.
+            tools: A list of tool definitions in OpenAI format.
+            tool_function_mapper: Map of tool names to Python callables.
+            tool_function_callable_kwargs: Static kwargs for tool callables.
+            conversation_mode: If True, history is preserved across asks.
+            max_tool_rounds: Limits recursive tool calls per ask.
+            **kwargs: Additional arguments for the OpenAI client or API.
+        """
         self.client = OpenAI(api_key=api_key, base_url=base_url)
         self.default_model = default_model
         self.instructions = instructions
         self.conversation_mode = conversation_mode
         self.max_tool_rounds = max_tool_rounds
-        
+
         self.messages = messages or []
         if not self.messages and self.instructions:
             self.messages = [{"role": "system", "content": self.instructions}]
 
-        self.function_tools = [
+        # Use the centralized ToolSet for management.
+        self.tool_set = ToolSet([
             FunctionTool(t, tool_function_mapper, tool_function_callable_kwargs)
             for t in (tools or []) if t.get("type") == "function"
-        ]
+        ])
         self.latest_tool_call_result = {}
 
         create_params = signature(self.client.chat.completions.create).parameters
-        self.openai_args_dict = {k: v for k, v in kwargs.items() if k in create_params}
+        self.openai_args_dict = {
+            k: v for k, v in kwargs.items() if k in create_params
+        }
 
         LOGGER.info(f"OpenAIChat initialized (model: {default_model})")
 
-    @staticmethod
-    def build_user_message_content(prompt: str, images: Optional[List[PILImage.Image]] = None) -> Union[str, List[Dict[str, Any]]]:
-        if not images:
-            return prompt
-        content = [{"type": "text", "text": prompt}]
-        for img in images:
-            if not isinstance(img, PILImage.Image):
-                raise TypeError("Images must be PIL instances.")
-            content.append({"type": "image_url", "image_url": {"url": convert_image_to_data_url(img)}})
-        return content
-
     def _extract_usage(self, usage: Any) -> TokenUsage:
-        if not usage: return TokenUsage()
+        """Extracts TokenUsage from an OpenAI usage object.
+
+        Args:
+            usage: The usage object returned by the OpenAI SDK.
+
+        Returns:
+            A populated TokenUsage instance.
+        """
+        if not usage:
+            return TokenUsage()
         return TokenUsage(
             input_tokens=getattr(usage, "prompt_tokens", 0),
             output_tokens=getattr(usage, "completion_tokens", 0),
-            total_tokens=getattr(usage, "total_tokens", 0)
-        )
+            total_tokens=getattr(usage, "total_tokens", 0))
 
-    def _parse_completion(self, completion: Any) -> Tuple[str, List[Dict[str, Any]], str, TokenUsage]:
+    def _parse_completion(
+            self,
+            completion: Any) -> Tuple[str, List[Dict[str, Any]], str, TokenUsage]:
+        """Parses a standard ChatCompletion object.
+
+        Args:
+            completion: The completion object from the OpenAI SDK.
+
+        Returns:
+            A tuple of (content, tool_calls, reasoning, usage).
+        """
         choice = completion.choices[0]
         content = choice.message.content or ""
         tool_calls = []
         if choice.message.tool_calls:
-            tool_calls = [
-                {"id": tc.id, "type": "function", "function": {"name": tc.function.name, "arguments": tc.function.arguments}}
-                for tc in choice.message.tool_calls
-            ]
+            tool_calls = [{
+                "id": tc.id,
+                "type": "function",
+                "function": {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments
+                }
+            } for tc in choice.message.tool_calls]
         reasoning = getattr(choice.message, "reasoning_content", "")
         usage = self._extract_usage(completion.usage)
         return content, tool_calls, reasoning, usage
 
-    def _parse_stream(self, stream: Any) -> Tuple[str, List[Dict[str, Any]], str, TokenUsage]:
+    def _parse_stream(
+            self,
+            stream: Any) -> Tuple[str, List[Dict[str, Any]], str, TokenUsage]:
+        """Parses a streaming ChatCompletion response.
+
+        Args:
+            stream: The stream generator from the OpenAI SDK.
+
+        Returns:
+            A tuple of (content, tool_calls, reasoning, usage) aggregated
+            from all chunks.
+        """
         content = ""
         tool_calls = []
         reasoning = ""
         usage = TokenUsage()
-        
+
         for chunk in stream:
             if chunk.usage:
                 usage = self._extract_usage(chunk.usage)
-            if not chunk.choices: continue
+            if not chunk.choices:
+                continue
             delta = chunk.choices[0].delta
-            if delta.content: content += delta.content
+            if delta.content:
+                content += delta.content
             if hasattr(delta, "reasoning_content") and delta.reasoning_content:
                 reasoning += delta.reasoning_content
             if delta.tool_calls:
                 for tc_chunk in delta.tool_calls:
                     while len(tool_calls) <= tc_chunk.index:
-                        tool_calls.append({"id": "", "type": "function", "function": {"name": "", "arguments": ""}})
+                        tool_calls.append({
+                            "id": "",
+                            "type": "function",
+                            "function": {
+                                "name": "",
+                                "arguments": ""
+                            }
+                        })
                     tc = tool_calls[tc_chunk.index]
-                    if tc_chunk.id: tc["id"] = tc_chunk.id
+                    if tc_chunk.id:
+                        tc["id"] = tc_chunk.id
                     if tc_chunk.function:
-                        if tc_chunk.function.name: tc["function"]["name"] = tc_chunk.function.name
-                        if tc_chunk.function.arguments: tc["function"]["arguments"] += tc_chunk.function.arguments
+                        if tc_chunk.function.name:
+                            tc["function"]["name"] = tc_chunk.function.name
+                        if tc_chunk.function.arguments:
+                            tc["function"][
+                                "arguments"] += tc_chunk.function.arguments
         return content, tool_calls, reasoning, usage
 
-    def chat_completion(self, messages: List[Dict[str, str]], model: Optional[str] = None, **kwargs: Any) -> LLMResponse:
+    def chat_completion(self,
+                        messages: List[Dict[str, str]],
+                        model: Optional[str] = None,
+                        **kwargs: Any) -> LLMResponse:
+        """Sends a single chat completion request.
+
+        Args:
+            messages: Conversation context.
+            model: Specific model ID to use.
+            **kwargs: Extra parameters for the API.
+
+        Returns:
+            An LLMResponse containing the model's output.
+        """
         try:
             target_model = model or self.default_model
             args = {**self.openai_args_dict, **kwargs}
-            completion = self.client.chat.completions.create(model=target_model, messages=messages, **args)
-            content, tool_calls, reasoning, usage = self._parse_completion(completion)
-            return LLMResponse(True, 200, content, usage=usage, tool_calls=tool_calls, reasoning_content=reasoning, raw_response=completion)
+            completion = self.client.chat.completions.create(
+                model=target_model, messages=messages, **args)
+            content, tool_calls, reasoning, usage = self._parse_completion(
+                completion)
+            return LLMResponse(True,
+                               200,
+                               content,
+                               usage=usage,
+                               tool_calls=tool_calls,
+                               reasoning_content=reasoning,
+                               raw_response=completion)
         except Exception as e:
             return LLMResponse(False, 500, f"Error: {e}")
 
-    def ask(self, prompt: str, images: Optional[List[PILImage.Image]] = None, stream: bool = True, **kwargs: Any) -> LLMResponse:
+    def ask(self,
+            prompt: str,
+            images: Optional[List[PILImage.Image]] = None,
+            stream: bool = True,
+            **kwargs: Any) -> LLMResponse:
+        """Orchestrates a chat interaction, handling history and tool calls.
+
+        Args:
+            prompt: The user's input text.
+            images: Optional list of images for multimodal input.
+            stream: Whether to use streaming for API calls.
+            **kwargs: Additional parameters for the model.
+
+        Returns:
+            An LLMResponse containing the final answer and usage metadata.
+        """
         try:
             user_content = self.build_user_message_content(prompt, images)
-            
-            # Use local messages to prevent state pollution on error
-            current_messages = self.messages.copy() if self.conversation_mode else []
+
+            # Use local messages to prevent state pollution on error.
+            current_messages = self.messages.copy(
+            ) if self.conversation_mode else []
             if not current_messages and self.instructions:
-                current_messages.append({"role": "system", "content": self.instructions})
+                current_messages.append({
+                    "role": "system",
+                    "content": self.instructions
+                })
             current_messages.append({"role": "user", "content": user_content})
 
-            tools_defs = [t.tool_definition_dict for t in self.function_tools] if self.function_tools else None
-            
+            tools_defs = (self.tool_set.get_openai_schema()
+                          if self.tool_set else None)
+
             final_content = ""
             final_reasoning = ""
             total_usage = TokenUsage()
-            
+
             round_idx = 0
             while round_idx < self.max_tool_rounds:
                 round_idx += 1
@@ -167,13 +262,16 @@ class OpenAIChat(BaseLLMClient):
                     **self.openai_args_dict,
                     **kwargs
                 }
-                
-                response = self.client.chat.completions.create(**completion_args)
+
+                response = self.client.chat.completions.create(
+                    **completion_args)
                 if stream:
-                    content, tool_calls, reasoning, usage = self._parse_stream(response)
+                    content, tool_calls, reasoning, usage = self._parse_stream(
+                        response)
                 else:
-                    content, tool_calls, reasoning, usage = self._parse_completion(response)
-                
+                    content, tool_calls, reasoning, usage = self._parse_completion(
+                        response)
+
                 final_content = content
                 final_reasoning += reasoning
                 total_usage.input_tokens += usage.input_tokens
@@ -181,36 +279,36 @@ class OpenAIChat(BaseLLMClient):
                 total_usage.total_tokens += usage.total_tokens
 
                 if not tool_calls:
-                    # Final response obtained
+                    # Final response obtained.
                     break
 
-                # Handle Tool Calls
+                # Handle Tool Calls via centralized execute_tool_calls.
                 assistant_msg = {"role": "assistant", "tool_calls": tool_calls}
-                if content: assistant_msg["content"] = content
+                if content:
+                    assistant_msg["content"] = content
                 current_messages.append(assistant_msg)
-                
-                for tc in tool_calls:
-                    func_name = tc["function"]["name"]
-                    tool = next((t for t in self.function_tools if t.name == func_name), None)
-                    if tool:
-                        result = tool.execute(tc["function"]["arguments"])
-                        tool_output = str(result[1] if isinstance(result, tuple) else result)
-                        self.latest_tool_call_result[func_name] = result[0] if isinstance(result, tuple) else True
-                    else:
-                        tool_output = f"Tool '{func_name}' not found."
-                        self.latest_tool_call_result[func_name] = False
-                    
-                    current_messages.append({"tool_call_id": tc["id"], "role": "tool", "name": func_name, "content": tool_output})
 
-            # Loop finished or max rounds reached
+                tool_messages, tool_results = self.tool_set.execute_tool_calls(
+                    tool_calls)
+                current_messages.extend(tool_messages)
+                self.latest_tool_call_result.update(tool_results)
+
+            # Loop finished or max rounds reached.
             if final_content:
-                current_messages.append({"role": "assistant", "content": final_content})
-            
-            # Commit changes to self.messages only on success
+                current_messages.append({
+                    "role": "assistant",
+                    "content": final_content
+                })
+
+            # Commit changes to self.messages only on success.
             if self.conversation_mode:
                 self.messages = current_messages
 
-            return LLMResponse(True, 200, final_content, usage=total_usage, reasoning_content=final_reasoning)
+            return LLMResponse(True,
+                               200,
+                               final_content,
+                               usage=total_usage,
+                               reasoning_content=final_reasoning)
 
         except Exception as e:
             LOGGER.error(f"ask failed: {e}")

--- a/ark/llm/providers/openai_chat.py
+++ b/ark/llm/providers/openai_chat.py
@@ -21,7 +21,7 @@ from openai.types.chat import ChatCompletionChunk, ChatCompletion
 from PIL import Image as PILImage
 
 from ark.core.logger import LOGGER
-from ark.llm.entities import LLMResponse, TokenUsage
+from ark.llm.entities import LLMResponse, TokenUsage, ToolCall
 from ark.llm.providers.base import BaseLLMClient
 from ark.llm.tools import FunctionTool, ToolSet
 
@@ -224,9 +224,17 @@ class OpenAIChat(BaseLLMClient):
 
         # Final yield with full aggregated data for logic/tools, but empty content
         # to avoid duplication in the ask loop.
+        final_tool_calls = [
+            ToolCall(
+                id=tc["id"],
+                name=tc["function"]["name"],
+                arguments=tc["function"]["arguments"]
+            ) for tc in tool_calls
+        ]
+
         yield LLMResponse(
             success=True, status_code=200,
-            content="", tool_calls=tool_calls,
+            content="", tool_calls=final_tool_calls,
             reasoning_content="",
             usage=usage
         )
@@ -276,14 +284,30 @@ class OpenAIChat(BaseLLMClient):
                 # Handle Tool Calls.
                 assistant_msg = {
                     "role": "assistant",
-                    "tool_calls": response.tool_calls
+                    "tool_calls": [{
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.name,
+                            "arguments": tc.arguments
+                        }
+                    } for tc in response.tool_calls]
                 }
                 if response.content:
                     assistant_msg["content"] = response.content
                 current_messages.append(assistant_msg)
 
-                tool_messages, tool_results = self.tool_set.execute_tool_calls(
+                tool_outputs, tool_results = self.tool_set.execute_tool_calls(
                     response.tool_calls)
+
+                tool_messages = []
+                for tc, output in zip(response.tool_calls, tool_outputs):
+                    tool_messages.append({
+                        "tool_call_id": tc.id,
+                        "role": "tool",
+                        "name": tc.name,
+                        "content": str(output)
+                    })
                 current_messages.extend(tool_messages)
                 self.latest_tool_call_result.update(tool_results)
 
@@ -360,13 +384,32 @@ class OpenAIChat(BaseLLMClient):
                     break
 
                 # Handle Tool Calls.
-                assistant_msg = {"role": "assistant", "tool_calls": tool_calls}
+                assistant_msg = {
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.name,
+                            "arguments": tc.arguments
+                        }
+                    } for tc in tool_calls]
+                }
                 if current_round_content:
                     assistant_msg["content"] = current_round_content
                 current_messages.append(assistant_msg)
 
-                tool_messages, tool_results = self.tool_set.execute_tool_calls(
+                tool_outputs, tool_results = self.tool_set.execute_tool_calls(
                     tool_calls)
+
+                tool_messages = []
+                for tc, output in zip(tool_calls, tool_outputs):
+                    tool_messages.append({
+                        "tool_call_id": tc.id,
+                        "role": "tool",
+                        "name": tc.name,
+                        "content": str(output)
+                    })
                 current_messages.extend(tool_messages)
                 self.latest_tool_call_result.update(tool_results)
 
@@ -401,7 +444,7 @@ class OpenAIChat(BaseLLMClient):
 
     def __parse_completion(
             self, completion: ChatCompletion
-        ) -> Tuple[str, List[Dict[str, Any]], str, TokenUsage]:
+        ) -> Tuple[str, List[ToolCall], str, TokenUsage]:
         """Parses a standard ChatCompletion instance.
 
         Args:
@@ -414,14 +457,13 @@ class OpenAIChat(BaseLLMClient):
         content = choice.message.content or ""
         tool_calls = []
         if choice.message.tool_calls:
-            tool_calls = [{
-                "id": tc.id,
-                "type": "function",
-                "function": {
-                    "name": tc.function.name,
-                    "arguments": tc.function.arguments
-                }
-            } for tc in choice.message.tool_calls]
+            tool_calls = [
+                ToolCall(
+                    id=tc.id,
+                    name=tc.function.name,
+                    arguments=tc.function.arguments
+                ) for tc in choice.message.tool_calls
+            ]
         reasoning = getattr(choice.message, "reasoning_content", "")
         usage = self.__extract_usage(completion.usage)
         return content, tool_calls, reasoning, usage

--- a/ark/llm/providers/openai_chat.py
+++ b/ark/llm/providers/openai_chat.py
@@ -1,0 +1,271 @@
+#! python3
+# -*- encoding: utf-8 -*-
+"""OpenAI Chat Completion compatible interface with tool calling and history support.
+
+@File   :   openai_chat.py
+@Created:   2026/06/05 00:34
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+# Here put the import lib.
+
+from typing import Any, List, Dict, Optional, Union, Tuple, Callable
+from json import loads
+from inspect import signature
+from PIL import Image as PILImage
+
+from openai import (
+    OpenAI,
+    APIError,
+    RateLimitError,
+    BadRequestError,
+    APITimeoutError,
+    AuthenticationError,
+    InternalServerError,
+)
+
+from ark.llm.providers.base import BaseLLMClient
+from ark.llm.tools import FunctionTool
+from ark.core.logger import LOGGER
+from ark.core.image_service import convert_image_to_data_url
+
+class OpenAIChat(BaseLLMClient):
+    """
+    Client for OpenAI Chat Completion compatible APIs, supporting history and tools.
+    """
+
+    def __init__(
+        self, 
+        api_key: Optional[str] = None, 
+        base_url: Optional[str] = None,
+        default_model: str = "gpt-3.5-turbo",
+        instructions: str = "",
+        messages: List[Dict[str, str]] = None,
+        tools: List[Dict[str, Any]] = None,
+        tool_function_mapper: Dict[str, Callable] = None,
+        tool_function_callable_kwargs: Dict[str, Any] = None,
+        conversation_mode: bool = True,
+        **kwargs: Any
+    ):
+        """
+        Initializes the OpenAI Chat client.
+
+        Args:
+            api_key: API key for authentication.
+            base_url: Base URL for the API.
+            default_model: Default model to use.
+            instructions: System instructions to define the agent behavior.
+            messages: Initial conversation history.
+            tools: List of OpenAI-style tool definitions.
+            tool_function_mapper: Map of tool names to Python callables.
+            tool_function_callable_kwargs: Additional kwargs for tool callables.
+            conversation_mode: If True, retains conversation history.
+            **kwargs: Additional parameters for the OpenAI client and chat completions.
+        """
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.default_model = default_model
+        self.instructions = instructions
+        self.conversation_mode = conversation_mode
+        
+        # Initialize messages
+        if messages:
+            self.messages = messages
+        elif self.instructions:
+            self.messages = [{"role": "system", "content": self.instructions}]
+        else:
+            self.messages = []
+
+        # Initialize tools
+        tools = tools or []
+        tool_function_mapper = tool_function_mapper or {}
+        tool_function_callable_kwargs = tool_function_callable_kwargs or {}
+        
+        self.function_tools = [
+            FunctionTool(
+                tool_definition_dict=t, 
+                tool_function_mapper=tool_function_mapper,
+                tool_function_callable_kwargs=tool_function_callable_kwargs
+            ) for t in tools if t.get("type") == "function"
+        ]
+        self.latest_tool_call_result = {}
+
+        # Filter kwargs for chat completion
+        create_params = signature(self.client.chat.completions.create).parameters
+        self.openai_args_dict = {k: v for k, v in kwargs.items() if k in create_params}
+
+        LOGGER.info(f"Initialized OpenAIChat (model: {default_model}, conversation_mode: {conversation_mode})")
+
+    @staticmethod
+    def build_user_message_content(
+        prompt: str,
+        images: Optional[List[PILImage.Image]] = None,
+    ) -> Union[str, List[Dict[str, Any]]]:
+        """Builds message content, supporting multimodal input if images are provided."""
+        if not images:
+            return prompt
+
+        content = [{"type": "text", "text": prompt}]
+        for img in images:
+            if not isinstance(img, PILImage.Image):
+                raise TypeError("Each image must be a PIL.Image.Image instance.")
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": convert_image_to_data_url(img)},
+            })
+        return content
+
+    def chat_completion(
+        self, 
+        messages: List[Dict[str, str]], 
+        model: Optional[str] = None,
+        **kwargs: Any
+    ) -> Any:
+        """Low-level call to OpenAI API."""
+        target_model = model or self.default_model
+        merged_kwargs = {**self.openai_args_dict, **kwargs}
+        return self.client.chat.completions.create(
+            model=target_model,
+            messages=messages,
+            **merged_kwargs
+        )
+
+    def ask(
+        self, 
+        prompt: str, 
+        images: Optional[List[PILImage.Image]] = None,
+        stream: bool = True,
+        **kwargs: Any
+    ) -> Tuple[bool, int, str]:
+        """
+        High-level interface for chat, handling history, tools, and streaming.
+
+        Returns:
+            Tuple[bool, int, str]: (is_success, status_code, content)
+        """
+        try:
+            user_content = self.build_user_message_content(prompt, images)
+            
+            # Manage message history
+            if self.conversation_mode:
+                messages = self.messages.copy()
+            else:
+                messages = []
+                if self.instructions:
+                    messages.append({"role": "system", "content": self.instructions})
+            
+            messages.append({"role": "user", "content": user_content})
+
+            tools_definitions = [t.tool_definition_dict for t in self.function_tools] if self.function_tools else None
+
+            # First Call
+            response_content = ""
+            current_tool_calls = []
+            
+            completion_args = {
+                "messages": messages,
+                "model": self.default_model,
+                "tools": tools_definitions,
+                "stream": stream,
+                **self.openai_args_dict,
+                **kwargs
+            }
+
+            if stream:
+                response = self.client.chat.completions.create(**completion_args)
+                for chunk in response:
+                    if not chunk.choices: continue
+                    delta = chunk.choices[0].delta
+                    if delta.content:
+                        response_content += delta.content
+                    if delta.tool_calls:
+                        for tc_chunk in delta.tool_calls:
+                            while len(current_tool_calls) <= tc_chunk.index:
+                                current_tool_calls.append({"id": "", "type": "function", "function": {"name": "", "arguments": ""}})
+                            tc = current_tool_calls[tc_chunk.index]
+                            if tc_chunk.id: tc["id"] = tc_chunk.id
+                            if tc_chunk.function:
+                                if tc_chunk.function.name: tc["function"]["name"] = tc_chunk.function.name
+                                if tc_chunk.function.arguments: tc["function"]["arguments"] += tc_chunk.function.arguments
+            else:
+                response = self.client.chat.completions.create(**completion_args)
+                msg = response.choices[0].message
+                response_content = msg.content or ""
+                if msg.tool_calls:
+                    current_tool_calls = [
+                        {"id": tc.id, "type": "function", "function": {"name": tc.function.name, "arguments": tc.function.arguments}}
+                        for tc in msg.tool_calls
+                    ]
+
+            # Handle Tool Calls
+            if current_tool_calls:
+                messages.append({"role": "assistant", "tool_calls": current_tool_calls})
+                
+                for tc in current_tool_calls:
+                    func_name = tc["function"]["name"]
+                    tool = next((t for t in self.function_tools if t.name == func_name), None)
+                    
+                    if tool:
+                        result = tool.execute(tc["function"]["arguments"])
+                        # Logic from legacy: result might be (is_success, value)
+                        if isinstance(result, tuple) and len(result) == 2:
+                            is_success, tool_output = result
+                        else:
+                            is_success, tool_output = True, str(result)
+                        
+                        self.latest_tool_call_result[func_name] = is_success
+                    else:
+                        tool_output = f"Tool '{func_name}' not found."
+                        self.latest_tool_call_result[func_name] = False
+                    
+                    messages.append({
+                        "tool_call_id": tc["id"],
+                        "role": "tool",
+                        "name": func_name,
+                        "content": str(tool_output)
+                    })
+
+                # Second Call after tools
+                second_response = self.client.chat.completions.create(
+                    messages=messages,
+                    model=self.default_model,
+                    tools=tools_definitions,
+                    stream=stream,
+                    **self.openai_args_dict,
+                    **kwargs
+                )
+                
+                final_content = ""
+                if stream:
+                    for chunk in second_response:
+                        if chunk.choices[0].delta.content:
+                            final_content += chunk.choices[0].delta.content
+                else:
+                    final_content = second_response.choices[0].message.content or ""
+                
+                response_content = final_content
+
+            # Update History
+            if response_content:
+                messages.append({"role": "assistant", "content": response_content})
+            
+            if self.conversation_mode:
+                self.messages = messages
+
+            return True, 200, response_content
+
+        except RateLimitError:
+            return True, 429, "Rate Limit Error"
+        except BadRequestError as e:
+            return True, 400, f"Bad Request: {e}"
+        except APITimeoutError:
+            return False, 500, "API Timeout"
+        except AuthenticationError:
+            return False, 401, "Authentication Failed"
+        except InternalServerError:
+            return False, 500, "Internal Server Error"
+        except APIError as e:
+            return False, 500, f"API Error: {e}"
+        except Exception as e:
+            LOGGER.error(f"Unexpected error: {e}")
+            return False, 500, f"Unexpected error: {e}"

--- a/ark/llm/providers/openai_chat.py
+++ b/ark/llm/providers/openai_chat.py
@@ -250,8 +250,7 @@ class OpenAIChat(BaseLLMClient):
         try:
             user_content = self.build_user_message_content(prompt, images)
             current_messages = self.__prepare_messages(user_content)
-            tools_defs = (self.tool_set.get_openai_schema()
-                          if self.tool_set else None)
+            tools_defs = self.__build_tools_schema()
 
             total_usage = TokenUsage()
             final_content = ""
@@ -339,8 +338,7 @@ class OpenAIChat(BaseLLMClient):
         try:
             user_content = self.build_user_message_content(prompt, images)
             current_messages = self.__prepare_messages(user_content)
-            tools_defs = (self.tool_set.get_openai_schema()
-                          if self.tool_set else None)
+            tools_defs = self.__build_tools_schema()
 
             total_usage = TokenUsage()
             final_content = ""
@@ -461,6 +459,23 @@ class OpenAIChat(BaseLLMClient):
         reasoning = getattr(choice.message, "reasoning_content", "")
         usage = self.__extract_usage(completion.usage)
         return content, tool_calls, reasoning, usage
+
+    def __build_tools_schema(self) -> Optional[List[Dict[str, Any]]]:
+        """Builds tool schemas in OpenAI function format.
+
+        Returns:
+            A list of OpenAI-format tool schemas, or None if no tools are defined.
+        """
+        if not self.tool_set or not self.tool_set.tools:
+            return None
+        return [{
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.parameters_schema,
+            }
+        } for t in self.tool_set.tools]
 
     def __prepare_messages(self, user_content: Union[str, List[Dict[str, Any]]]) -> List[Dict[str, str]]:
         """Helper to prepare the message list for ask loops."""

--- a/ark/llm/providers/openai_chat.py
+++ b/ark/llm/providers/openai_chat.py
@@ -117,7 +117,7 @@ class OpenAIChat(BaseLLMClient):
         else:
             return self.__ask_loop(prompt, images, **kwargs)
 
-    def chat_completion(self,
+    def generate(self,
             messages: List[Dict[str, str]],
             model: Optional[str] = None,
             **kwargs: Any
@@ -148,7 +148,7 @@ class OpenAIChat(BaseLLMClient):
         except Exception as e:
             return LLMResponse(success=False, status_code=500, content=f"Error: {e}")
 
-    def chat_completion_stream(
+    def generate_stream(
             self, messages: List[Dict[str, str]],
             model: Optional[str] = None, **kwargs: Any
         ) -> Iterator[LLMResponse]:
@@ -258,7 +258,7 @@ class OpenAIChat(BaseLLMClient):
             round_idx = 0
             while round_idx < self.max_tool_rounds:
                 round_idx += 1
-                response = self.chat_completion(messages=current_messages,
+                response = self.generate(messages=current_messages,
                                                tools=tools_defs,
                                                **kwargs)
                 if not response.success:
@@ -336,7 +336,7 @@ class OpenAIChat(BaseLLMClient):
                 current_round_reasoning = ""
 
                 # Iterate through chunks from the streaming completion.
-                for chunk_resp in self.chat_completion_stream(
+                for chunk_resp in self.generate_stream(
                         messages=current_messages, tools=tools_defs, **kwargs):
                     
                     if chunk_resp.tool_calls:

--- a/ark/llm/providers/openai_chat.py
+++ b/ark/llm/providers/openai_chat.py
@@ -9,12 +9,15 @@
 """
 
 from inspect import signature
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 from openai import (
     BadRequestError,
     OpenAI,
+    Stream,
 )
+from openai.types import CompletionUsage
+from openai.types.chat import ChatCompletionChunk, ChatCompletion
 from PIL import Image as PILImage
 
 from ark.core.logger import LOGGER
@@ -27,7 +30,7 @@ class OpenAIChat(BaseLLMClient):
     """Optimized client for OpenAI Chat Completion compatible APIs.
 
     Supports structured LLMResponse, safe history mutation, and multi-turn
-    tool calling.
+    tool calling via internal orchestration loops.
 
     Attributes:
         client: The underlying OpenAI client instance.
@@ -37,22 +40,22 @@ class OpenAIChat(BaseLLMClient):
         max_tool_rounds: Maximum number of recursive tool-calling rounds.
         messages: The current conversation history.
         tool_set: A collection of available tools.
-        latest_tool_call_result: results of the last tool executions.
+        latest_tool_call_result: Results of the last tool executions.
         openai_args_dict: Filtered kwargs for the OpenAI SDK.
     """
 
     def __init__(self,
-                 api_key: Optional[str] = None,
-                 base_url: Optional[str] = None,
-                 default_model: str = "gpt-3.5-turbo",
-                 instructions: str = "",
-                 messages: List[Dict[str, str]] = None,
-                 tools: List[Dict[str, Any]] = None,
-                 tool_function_mapper: Dict[str, Callable] = None,
-                 tool_function_callable_kwargs: Dict[str, Any] = None,
-                 conversation_mode: bool = True,
-                 max_tool_rounds: int = 5,
-                 **kwargs: Any):
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        default_model: str = "gpt-3.5-turbo",
+        instructions: str = "",
+        messages: List[Dict[str, str]] = None,
+        tools: List[Dict[str, Any]] = None,
+        tool_function_mapper: Dict[str, Callable] = None,
+        tool_function_callable_kwargs: Dict[str, Any] = None,
+        conversation_mode: bool = True,
+        max_tool_rounds: int = 5,
+        **kwargs: Any):
         """Initializes an OpenAIChat client.
 
         Args:
@@ -92,76 +95,104 @@ class OpenAIChat(BaseLLMClient):
 
         LOGGER.info(f"OpenAIChat initialized (model: {default_model})")
 
-    def _extract_usage(self, usage: Any) -> TokenUsage:
-        """Extracts TokenUsage from an OpenAI usage object.
+    def ask(self,
+            prompt: str,
+            images: Optional[List[PILImage.Image]] = None,
+            stream: bool = False,
+            **kwargs: Any) -> Union[LLMResponse, Iterator[LLMResponse]]:
+        """Orchestrates a chat interaction, handling history and tool calls.
 
         Args:
-            usage: The usage object returned by the OpenAI SDK.
+            prompt (str): The user's input text.
+            images (Optional[List[PILImage.Image]]): Optional list of images for multimodal input.
+            stream (bool, optional): Whether to use streaming for the interaction. Defaults to False.
+            **kwargs: Additional parameters for the model.
 
         Returns:
-            A populated TokenUsage instance.
+            An LLMResponse (non-stream) or Iterator[LLMResponse] (stream).
         """
-        if not usage:
-            return TokenUsage()
-        return TokenUsage(
-            input_tokens=getattr(usage, "prompt_tokens", 0),
-            output_tokens=getattr(usage, "completion_tokens", 0),
-            total_tokens=getattr(usage, "total_tokens", 0))
+        if stream:
+            return self.__ask_loop_stream(prompt, images, **kwargs)
+        else:
+            return self.__ask_loop(prompt, images, **kwargs)
 
-    def _parse_completion(
-            self,
-            completion: Any) -> Tuple[str, List[Dict[str, Any]], str, TokenUsage]:
-        """Parses a standard ChatCompletion object.
+    def chat_completion(self,
+            messages: List[Dict[str, str]],
+            model: Optional[str] = None,
+            **kwargs: Any
+        ) -> LLMResponse:
+        """Sends a single non-streaming chat completion request.
 
         Args:
-            completion: The completion object from the OpenAI SDK.
+            messages: Conversation context.
+            model: Specific model ID to use.
+            **kwargs: Extra parameters for the API.
 
         Returns:
-            A tuple of (content, tool_calls, reasoning, usage).
+            An LLMResponse containing the model's output.
         """
-        choice = completion.choices[0]
-        content = choice.message.content or ""
-        tool_calls = []
-        if choice.message.tool_calls:
-            tool_calls = [{
-                "id": tc.id,
-                "type": "function",
-                "function": {
-                    "name": tc.function.name,
-                    "arguments": tc.function.arguments
-                }
-            } for tc in choice.message.tool_calls]
-        reasoning = getattr(choice.message, "reasoning_content", "")
-        usage = self._extract_usage(completion.usage)
-        return content, tool_calls, reasoning, usage
+        try:
+            target_model = model or self.default_model
+            args = {**self.openai_args_dict, **kwargs}
+            completion: ChatCompletion = self.client.chat.completions.create(
+                model=target_model, messages=messages, stream=False, **args)
+            content, tool_calls, reasoning, usage = self.__parse_completion(
+                completion)
+            return LLMResponse(
+                success=True, status_code=200,
+                content=content, usage=usage,
+                tool_calls=tool_calls, reasoning_content=reasoning,
+                raw_response=completion
+            )
+        except Exception as e:
+            return LLMResponse(success=False, status_code=500, content=f"Error: {e}")
 
-    def _parse_stream(
-            self,
-            stream: Any) -> Tuple[str, List[Dict[str, Any]], str, TokenUsage]:
-        """Parses a streaming ChatCompletion response.
+    def chat_completion_stream(
+            self, messages: List[Dict[str, str]],
+            model: Optional[str] = None, **kwargs: Any
+        ) -> Iterator[LLMResponse]:
+        """Sends a streaming chat completion request.
 
         Args:
-            stream: The stream generator from the OpenAI SDK.
+            messages: Conversation context.
+            model: Specific model ID to use.
+            **kwargs: Extra parameters for the API.
 
-        Returns:
-            A tuple of (content, tool_calls, reasoning, usage) aggregated
-            from all chunks.
+        Yields:
+            LLMResponse objects containing chunks or final results.
         """
+        target_model = model or self.default_model
+        args = {**self.openai_args_dict, **kwargs}
+
+        stream: Stream[ChatCompletionChunk] = self.client.chat.completions.create(
+            model=target_model, messages=messages,
+            stream=True, stream_options={"include_usage": True},
+            **args
+        )
+
         content = ""
         tool_calls = []
         reasoning = ""
         usage = TokenUsage()
 
         for chunk in stream:
-            if chunk.usage:
-                usage = self._extract_usage(chunk.usage)
+            chunk_usage = self.__extract_usage(chunk.usage) if chunk.usage else None
+            if chunk_usage:
+                usage = chunk_usage
+
             if not chunk.choices:
                 continue
+
             delta = chunk.choices[0].delta
-            if delta.content:
-                content += delta.content
-            if hasattr(delta, "reasoning_content") and delta.reasoning_content:
-                reasoning += delta.reasoning_content
+            delta_content = delta.content or ""
+            delta_reasoning = getattr(delta, "reasoning_content", "") or ""
+
+            if delta_content:
+                content += delta_content
+            if delta_reasoning:
+                reasoning += delta_reasoning
+
+            # Handle tool calls in stream.
             if delta.tool_calls:
                 for tc_chunk in delta.tool_calls:
                     while len(tool_calls) <= tc_chunk.index:
@@ -180,112 +211,157 @@ class OpenAIChat(BaseLLMClient):
                         if tc_chunk.function.name:
                             tc["function"]["name"] = tc_chunk.function.name
                         if tc_chunk.function.arguments:
-                            tc["function"][
-                                "arguments"] += tc_chunk.function.arguments
-        return content, tool_calls, reasoning, usage
+                            tc["function"]["arguments"] += tc_chunk.function.arguments
 
-    def chat_completion(self,
-                        messages: List[Dict[str, str]],
-                        model: Optional[str] = None,
-                        **kwargs: Any) -> LLMResponse:
-        """Sends a single chat completion request.
+            # Yield incremental text chunks.
+            if delta_content or delta_reasoning:
+                yield LLMResponse(
+                    success=True, status_code=200,
+                    content=delta_content, reasoning_content=delta_reasoning,
+                    raw_response=chunk
+                )
 
-        Args:
-            messages: Conversation context.
-            model: Specific model ID to use.
-            **kwargs: Extra parameters for the API.
+        # Final yield with full aggregated data for logic/tools, but empty content
+        # to avoid duplication in the ask loop.
+        yield LLMResponse(
+            success=True, status_code=200,
+            content="", tool_calls=tool_calls,
+            reasoning_content="",
+            usage=usage
+        )
 
-        Returns:
-            An LLMResponse containing the model's output.
-        """
-        try:
-            target_model = model or self.default_model
-            args = {**self.openai_args_dict, **kwargs}
-            completion = self.client.chat.completions.create(
-                model=target_model, messages=messages, **args)
-            content, tool_calls, reasoning, usage = self._parse_completion(
-                completion)
-            return LLMResponse(True,
-                               200,
-                               content,
-                               usage=usage,
-                               tool_calls=tool_calls,
-                               reasoning_content=reasoning,
-                               raw_response=completion)
-        except Exception as e:
-            return LLMResponse(False, 500, f"Error: {e}")
-
-    def ask(self,
-            prompt: str,
-            images: Optional[List[PILImage.Image]] = None,
-            stream: bool = True,
-            **kwargs: Any) -> LLMResponse:
-        """Orchestrates a chat interaction, handling history and tool calls.
+    def __ask_loop(self,
+                  prompt: str,
+                  images: Optional[List[PILImage.Image]] = None,
+                  **kwargs: Any) -> LLMResponse:
+        """Internal loop for non-streaming interaction.
 
         Args:
-            prompt: The user's input text.
-            images: Optional list of images for multimodal input.
-            stream: Whether to use streaming for API calls.
-            **kwargs: Additional parameters for the model.
+            prompt: User prompt.
+            images: Multimodal inputs.
+            **kwargs: API arguments.
 
         Returns:
-            An LLMResponse containing the final answer and usage metadata.
+            Final LLMResponse after all tool calls.
         """
         try:
             user_content = self.build_user_message_content(prompt, images)
-
-            # Use local messages to prevent state pollution on error.
-            current_messages = self.messages.copy(
-            ) if self.conversation_mode else []
-            if not current_messages and self.instructions:
-                current_messages.append({
-                    "role": "system",
-                    "content": self.instructions
-                })
-            current_messages.append({"role": "user", "content": user_content})
-
+            current_messages = self.__prepare_messages(user_content)
             tools_defs = (self.tool_set.get_openai_schema()
                           if self.tool_set else None)
 
+            total_usage = TokenUsage()
             final_content = ""
             final_reasoning = ""
-            total_usage = TokenUsage()
 
             round_idx = 0
             while round_idx < self.max_tool_rounds:
                 round_idx += 1
-                completion_args = {
-                    "messages": current_messages,
-                    "model": self.default_model,
-                    "tools": tools_defs,
-                    "stream": stream,
-                    **self.openai_args_dict,
-                    **kwargs
-                }
+                response = self.chat_completion(messages=current_messages,
+                                               tools=tools_defs,
+                                               **kwargs)
+                if not response.success:
+                    return response
 
-                response = self.client.chat.completions.create(
-                    **completion_args)
-                if stream:
-                    content, tool_calls, reasoning, usage = self._parse_stream(
-                        response)
-                else:
-                    content, tool_calls, reasoning, usage = self._parse_completion(
-                        response)
+                total_usage.input_tokens += response.usage.input_tokens
+                total_usage.output_tokens += response.usage.output_tokens
+                total_usage.total_tokens += response.usage.total_tokens
+                final_reasoning += response.reasoning_content
 
-                final_content = content
-                final_reasoning += reasoning
-                total_usage.input_tokens += usage.input_tokens
-                total_usage.output_tokens += usage.output_tokens
-                total_usage.total_tokens += usage.total_tokens
-
-                if not tool_calls:
-                    # Final response obtained.
+                if not response.tool_calls:
+                    final_content = response.content
                     break
 
-                # Handle Tool Calls via centralized execute_tool_calls.
+                # Handle Tool Calls.
+                assistant_msg = {
+                    "role": "assistant",
+                    "tool_calls": response.tool_calls
+                }
+                if response.content:
+                    assistant_msg["content"] = response.content
+                current_messages.append(assistant_msg)
+
+                tool_messages, tool_results = self.tool_set.execute_tool_calls(
+                    response.tool_calls)
+                current_messages.extend(tool_messages)
+                self.latest_tool_call_result.update(tool_results)
+
+            if final_content:
+                current_messages.append({
+                    "role": "assistant",
+                    "content": final_content
+                })
+            if self.conversation_mode:
+                self.messages = current_messages
+
+            return LLMResponse(
+                success=True, status_code=200,
+                content=final_content, usage=total_usage,
+                reasoning_content=final_reasoning
+            )
+
+        except Exception as e:
+            return self.__handle_ask_exception(e)
+
+    def __ask_loop_stream(self,
+                         prompt: str,
+                         images: Optional[List[PILImage.Image]] = None,
+                         **kwargs: Any) -> Iterator[LLMResponse]:
+        """Internal loop for streaming interaction.
+
+        Args:
+            prompt: User prompt.
+            images: Multimodal inputs.
+            **kwargs: API arguments.
+
+        Yields:
+            Incremental chunks and final summary.
+        """
+        try:
+            user_content = self.build_user_message_content(prompt, images)
+            current_messages = self.__prepare_messages(user_content)
+            tools_defs = (self.tool_set.get_openai_schema()
+                          if self.tool_set else None)
+
+            total_usage = TokenUsage()
+            final_content = ""
+            final_reasoning = ""
+
+            round_idx = 0
+            while round_idx < self.max_tool_rounds:
+                round_idx += 1
+                tool_calls = []
+                current_round_content = ""
+                current_round_reasoning = ""
+
+                # Iterate through chunks from the streaming completion.
+                for chunk_resp in self.chat_completion_stream(
+                        messages=current_messages, tools=tools_defs, **kwargs):
+                    
+                    if chunk_resp.tool_calls:
+                        tool_calls = chunk_resp.tool_calls
+                    if chunk_resp.usage:
+                        total_usage.input_tokens += chunk_resp.usage.input_tokens
+                        total_usage.output_tokens += chunk_resp.usage.output_tokens
+                        total_usage.total_tokens += chunk_resp.usage.total_tokens
+                    
+                    # chunk_resp.content is incremental in chunks, empty in final.
+                    if chunk_resp.content or chunk_resp.reasoning_content or chunk_resp.usage.total_tokens > 0:
+                        current_round_content += chunk_resp.content
+                        current_round_reasoning += chunk_resp.reasoning_content
+                        # Forward the increment or final summary to the user.
+                        yield chunk_resp
+
+                final_reasoning += current_round_reasoning
+
+                if not tool_calls:
+                    final_content = current_round_content
+                    break
+
+                # Handle Tool Calls.
                 assistant_msg = {"role": "assistant", "tool_calls": tool_calls}
-                if content:
-                    assistant_msg["content"] = content
+                if current_round_content:
+                    assistant_msg["content"] = current_round_content
                 current_messages.append(assistant_msg)
 
                 tool_messages, tool_results = self.tool_set.execute_tool_calls(
@@ -293,24 +369,72 @@ class OpenAIChat(BaseLLMClient):
                 current_messages.extend(tool_messages)
                 self.latest_tool_call_result.update(tool_results)
 
-            # Loop finished or max rounds reached.
             if final_content:
                 current_messages.append({
                     "role": "assistant",
                     "content": final_content
                 })
-
-            # Commit changes to self.messages only on success.
             if self.conversation_mode:
                 self.messages = current_messages
 
-            return LLMResponse(True,
-                               200,
-                               final_content,
-                               usage=total_usage,
-                               reasoning_content=final_reasoning)
-
         except Exception as e:
-            LOGGER.error(f"ask failed: {e}")
-            status = 400 if isinstance(e, BadRequestError) else 500
-            return LLMResponse(False, status, f"Unexpected error: {e}")
+            yield self.__handle_ask_exception(e)
+
+    def __extract_usage(self, usage: Optional[CompletionUsage]) -> TokenUsage:
+        """Extracts TokenUsage from an OpenAI usage object.
+
+        Args:
+            usage (Optional[CompletionUsage]): The usage object returned by the OpenAI SDK.
+
+        Returns:
+            A populated TokenUsage instance.
+        """
+        if not usage:
+            return TokenUsage()
+        else:
+            return TokenUsage(
+                input_tokens=usage.prompt_tokens,
+                output_tokens=usage.completion_tokens,
+                total_tokens=usage.total_tokens
+            )
+
+    def __parse_completion(
+            self, completion: ChatCompletion
+        ) -> Tuple[str, List[Dict[str, Any]], str, TokenUsage]:
+        """Parses a standard ChatCompletion instance.
+
+        Args:
+            completion (ChatCompletion): The ChatCompletion instance from the OpenAI SDK.
+
+        Returns:
+            A tuple of (content, tool_calls, reasoning, usage).
+        """
+        choice = completion.choices[0]
+        content = choice.message.content or ""
+        tool_calls = []
+        if choice.message.tool_calls:
+            tool_calls = [{
+                "id": tc.id,
+                "type": "function",
+                "function": {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments
+                }
+            } for tc in choice.message.tool_calls]
+        reasoning = getattr(choice.message, "reasoning_content", "")
+        usage = self.__extract_usage(completion.usage)
+        return content, tool_calls, reasoning, usage
+
+    def __prepare_messages(self, user_content: Union[str, List[Dict[str, Any]]]) -> List[Dict[str, str]]:
+        """Helper to prepare the message list for ask loops."""
+        messages = self.messages.copy() if self.conversation_mode else []
+        if not messages and self.instructions:
+            messages.append({"role": "system", "content": self.instructions})
+        messages.append({"role": "user", "content": user_content})
+        return messages
+
+    def __handle_ask_exception(self, e: Exception) -> LLMResponse:
+        """Helper to handle exceptions in ask loops."""
+        LOGGER.error(f"ask failed: {e}")
+        status = 400 if isinstance(e, BadRequestError) else 500
+        return LLMResponse(success=False, status_code=status, content=f"Unexpected error: {e}")

--- a/ark/llm/providers/openai_chat.py
+++ b/ark/llm/providers/openai_chat.py
@@ -83,7 +83,8 @@ class OpenAIChat(BaseLLMClient):
 
         # Use the centralized ToolSet for management.
         self.tool_set = ToolSet([
-            FunctionTool(t, tool_function_mapper, tool_function_callable_kwargs)
+            FunctionTool.from_openai_schema(
+                t, tool_function_mapper, tool_function_callable_kwargs)
             for t in (tools or []) if t.get("type") == "function"
         ])
         self.latest_tool_call_result = {}

--- a/ark/llm/providers/openai_chat.py
+++ b/ark/llm/providers/openai_chat.py
@@ -50,9 +50,7 @@ class OpenAIChat(BaseLLMClient):
         default_model: str = "gpt-3.5-turbo",
         instructions: str = "",
         messages: List[Dict[str, str]] = None,
-        tools: List[Dict[str, Any]] = None,
-        tool_function_mapper: Dict[str, Callable] = None,
-        tool_function_callable_kwargs: Dict[str, Any] = None,
+        tools: Union[ToolSet, List[FunctionTool], None] = None,
         conversation_mode: bool = True,
         max_tool_rounds: int = 5,
         **kwargs: Any):
@@ -64,9 +62,7 @@ class OpenAIChat(BaseLLMClient):
             default_model: The default model ID.
             instructions: System instructions for the model.
             messages: Initial list of conversation messages.
-            tools: A list of tool definitions in OpenAI format.
-            tool_function_mapper: Map of tool names to Python callables.
-            tool_function_callable_kwargs: Static kwargs for tool callables.
+            tools: An optional ToolSet or list of FunctionTool objects.
             conversation_mode: If True, history is preserved across asks.
             max_tool_rounds: Limits recursive tool calls per ask.
             **kwargs: Additional arguments for the OpenAI client or API.
@@ -81,12 +77,10 @@ class OpenAIChat(BaseLLMClient):
         if not self.messages and self.instructions:
             self.messages = [{"role": "system", "content": self.instructions}]
 
-        # Use the centralized ToolSet for management.
-        self.tool_set = ToolSet([
-            FunctionTool.from_openai_schema(
-                t, tool_function_mapper, tool_function_callable_kwargs)
-            for t in (tools or []) if t.get("type") == "function"
-        ])
+        if isinstance(tools, ToolSet):
+            self.tool_set = tools
+        else:
+            self.tool_set = ToolSet(tools or [])
         self.latest_tool_call_result = {}
 
         create_params = signature(self.client.chat.completions.create).parameters

--- a/ark/llm/tools/__init__.py
+++ b/ark/llm/tools/__init__.py
@@ -1,5 +1,5 @@
 #! python3
 # -*- coding: utf-8 -*-
-from ark.llm.tools.base import FunctionTool, FunctionToolParameter
+from ark.llm.tools.base import FunctionTool, FunctionToolParameter, ToolSet
 
-__all__ = ["FunctionTool", "FunctionToolParameter"]
+__all__ = ["FunctionTool", "FunctionToolParameter", "ToolSet"]

--- a/ark/llm/tools/__init__.py
+++ b/ark/llm/tools/__init__.py
@@ -1,5 +1,5 @@
 #! python3
 # -*- coding: utf-8 -*-
-from ark.llm.tools.base import FunctionTool, FunctionToolParameter, ToolSet
+from ark.llm.tools.base import FunctionTool, ToolSet
 
-__all__ = ["FunctionTool", "FunctionToolParameter", "ToolSet"]
+__all__ = ["FunctionTool", "ToolSet"]

--- a/ark/llm/tools/__init__.py
+++ b/ark/llm/tools/__init__.py
@@ -1,0 +1,5 @@
+#! python3
+# -*- coding: utf-8 -*-
+from ark.llm.tools.base import FunctionTool, FunctionToolParameter
+
+__all__ = ["FunctionTool", "FunctionToolParameter"]

--- a/ark/llm/tools/base.py
+++ b/ark/llm/tools/base.py
@@ -17,202 +17,123 @@ tool definition can move between providers without loss.
 """
 
 from json import loads
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+import inspect
+import re
+from typing import Any, Callable, Dict, List, Optional, Tuple, get_type_hints
 
-if TYPE_CHECKING:
-    from ark.llm.entities import ToolCall
+from ark.llm.entities import ToolCall
 
-
-class FunctionToolParameter():
-    """Represents a parameter for a function tool.
-
-    Attributes:
-        key: The technical key/name of the parameter.
-        param_type: The data type of the parameter (e.g., 'string', 'integer').
-        description: A brief description of what the parameter represents.
-        required: Whether the parameter must be provided by the LLM.
-        value: The current value assigned to this parameter.
-    """
-
-    def __init__(self, key: str, param_type: str, description: str,
-                 required: bool):
-        """Initializes a FunctionToolParameter instance."""
-        self.key = key
-        self.param_type = param_type
-        self.description = description
-        self.required = required
-        self.value: Any = None
-
-    @property
-    def name(self) -> str:
-        """Returns the technical name of the parameter."""
-        return self.key
-
-    @name.setter
-    def name(self, value: str):
-        """Sets the technical name of the parameter."""
-        self.key = value
-
-    @staticmethod
-    def parse_function_parameters(
-            parameters_dict: dict) -> List['FunctionToolParameter']:
-        """Parses parameter info from a JSON-Schema parameters object.
-
-        Args:
-            parameters_dict: A JSON-Schema object with ``properties``/``required``.
-
-        Returns:
-            A list of FunctionToolParameter instances.
-        """
-        properties: Dict[str, dict] = parameters_dict.get("properties", {})
-        required_params: list = parameters_dict.get("required", [])
-
-        parameters = []
-        for key, value in properties.items():
-            param_type = value.get("type", "string")
-            description = value.get("description", "")
-            required = (key in required_params)
-            parameters.append(
-                FunctionToolParameter(key=key,
-                                      param_type=param_type,
-                                      description=description,
-                                      required=required))
-
-        return parameters
-
-
-class FunctionTool():
+class FunctionTool:
     """A provider-neutral tool the LLM can call to perform actions.
 
     The neutral core is ``name`` / ``description`` / ``parameters_schema`` (a
-    JSON-Schema object). Vendor wire formats are produced on demand via
-    ``to_openai_schema`` / ``to_anthropic_schema`` and ingested via the
-    ``from_*`` classmethods. Holding the full JSON-Schema object (rather than a
-    flattened parameter list) keeps details such as ``enum`` constraints and
-    nested object types intact across conversions.
+    JSON-Schema object). It also holds the Python ``mapped_callable`` to execute.
 
     Attributes:
         name: The name of the function.
         description: A brief description of the tool's purpose.
-        parameters_schema: The JSON-Schema object describing the inputs (the
-            shared inner shape used by both OpenAI and Anthropic).
+        parameters_schema: The JSON-Schema object describing the inputs.
         mapped_callable: The Python function associated with this tool.
         tool_function_callable_kwargs: Extra kwargs for the mapped callable.
     """
 
     def __init__(self,
-                 name: str,
+                 mapped_callable: Callable,
+                 name: Optional[str] = None,
                  description: str = "",
-                 parameters_schema: Dict[str, Any] = None,
-                 mapped_callable: Optional[Callable] = None,
+                 parameters_schema: Optional[Dict[str, Any]] = None,
                  tool_function_callable_kwargs: Dict[str, Any] = None):
         """Initializes a FunctionTool from neutral fields.
 
+        If ``parameters_schema`` is omitted, this attempts to auto-generate
+        the schema using `inspect.signature` and typing hints. It uses
+        best-effort parsing to extract parameter descriptions from the docstring.
+
         Args:
-            name: The tool/function name.
-            description: A human-readable description of the tool.
-            parameters_schema: The JSON-Schema inputs object (defaults to an
-                empty object schema).
             mapped_callable: The Python callable that backs this tool.
+            name: The tool/function name (defaults to callable's name).
+            description: A human-readable description (defaults to first docstring line).
+            parameters_schema: The JSON-Schema inputs object.
             tool_function_callable_kwargs: Static kwargs to pass to the callable.
         """
-        self.name = name
-        self.description = description
-        self.parameters_schema: Dict[str, Any] = (
-            parameters_schema or {"type": "object", "properties": {}})
         self.mapped_callable = mapped_callable
+        self.name = name or mapped_callable.__name__
+
+        if description:
+            self.description = description
+        elif mapped_callable.__doc__:
+            # Use the first non-empty line of the docstring as the default description
+            lines = [line.strip() for line in mapped_callable.__doc__.split('\n') if line.strip()]
+            self.description = lines[0] if lines else ""
+        else:
+            self.description = ""
+
+        if parameters_schema is not None:
+            self.parameters_schema = parameters_schema
+        else:
+            self.parameters_schema = self.__generate_schema_from_callable(mapped_callable)
+
         self.tool_function_callable_kwargs = tool_function_callable_kwargs or {}
 
-    @property
-    def parameters(self) -> List[FunctionToolParameter]:
-        """Returns the parameters parsed from ``parameters_schema`` on demand."""
-        return FunctionToolParameter.parse_function_parameters(
-            self.parameters_schema)
-
     @classmethod
-    def from_openai_schema(
-            cls,
-            tool_definition_dict: Dict[str, Any],
-            tool_function_mapper: Dict[str, Callable] = None,
-            tool_function_callable_kwargs: Dict[str, Any] = None
-    ) -> 'FunctionTool':
-        """Builds a FunctionTool from an OpenAI-style tool definition.
+    def __generate_schema_from_callable(cls, func: Callable) -> Dict[str, Any]:
+        sig = inspect.signature(func)
+        type_hints = get_type_hints(func)
 
-        Args:
-            tool_definition_dict: OpenAI ``{"type": "function", "function": {...}}``.
-            tool_function_mapper: A map of tool names to Python callables.
-            tool_function_callable_kwargs: Static kwargs to pass to callables.
-
-        Returns:
-            A FunctionTool instance.
-        """
-        function_dict = tool_definition_dict.get("function", {})
-        name = function_dict.get("name", "")
-        return cls(
-            name=name,
-            description=function_dict.get("description", ""),
-            parameters_schema=function_dict.get("parameters"),
-            mapped_callable=(tool_function_mapper or {}).get(name),
-            tool_function_callable_kwargs=tool_function_callable_kwargs,
-        )
-
-    @classmethod
-    def from_anthropic_schema(
-            cls,
-            tool_definition_dict: Dict[str, Any],
-            tool_function_mapper: Dict[str, Callable] = None,
-            tool_function_callable_kwargs: Dict[str, Any] = None
-    ) -> 'FunctionTool':
-        """Builds a FunctionTool from an Anthropic-style tool definition.
-
-        Args:
-            tool_definition_dict: Anthropic ``{"name", "description", "input_schema"}``.
-            tool_function_mapper: A map of tool names to Python callables.
-            tool_function_callable_kwargs: Static kwargs to pass to callables.
-
-        Returns:
-            A FunctionTool instance.
-        """
-        name = tool_definition_dict.get("name", "")
-        return cls(
-            name=name,
-            description=tool_definition_dict.get("description", ""),
-            parameters_schema=tool_definition_dict.get("input_schema"),
-            mapped_callable=(tool_function_mapper or {}).get(name),
-            tool_function_callable_kwargs=tool_function_callable_kwargs,
-        )
-
-    def to_openai_schema(self) -> Dict[str, Any]:
-        """Renders this tool as an OpenAI-style tool definition.
-
-        Returns:
-            An OpenAI ``{"type": "function", "function": {...}}`` dictionary.
-        """
-        return {
-            "type": "function",
-            "function": {
-                "name": self.name,
-                "description": self.description,
-                "parameters": self.parameters_schema,
-            },
+        # Mapping of Python types to JSON Schema types
+        type_mapping = {
+            str: "string", int: "integer", float: "number",
+            bool: "boolean", list: "array", dict: "object", type(None): "null"
         }
 
-    def to_anthropic_schema(self) -> Dict[str, Any]:
-        """Renders this tool as an Anthropic-style tool definition.
+        # Best-effort docstring parameter parsing (Google/Sphinx style)
+        param_descriptions = {}
+        if func.__doc__:
+            # Look for lines like "param_name: description" or "param_name (type): description"
+            # under an "Args:" section.
+            doc_lines = func.__doc__.split('\n')
+            in_args_section = False
+            for line in doc_lines:
+                line = line.strip()
+                if line.startswith("Args:") or line.startswith("Parameters:"):
+                    in_args_section = True
+                    continue
+                if in_args_section:
+                    if not line or line.endswith(":"): # Empty line or next section
+                        # A very crude check to stop parsing args if we hit another section like "Returns:"
+                        if re.match(r"^[A-Z][a-z]+:$", line):
+                            break
+                        continue
 
-        Returns:
-            An Anthropic ``{"name", "description", "input_schema"}`` dictionary.
-            ``input_schema`` always carries ``"type": "object"`` as Anthropic
-            requires.
-        """
-        schema = self.parameters_schema
-        if "type" not in schema:
-            schema = {**schema, "type": "object"}
-        return {
-            "name": self.name,
-            "description": self.description,
-            "input_schema": schema,
-        }
+                    # Match "param_name: description" or "param_name (type): description"
+                    match = re.match(r"^([a-zA-Z0-9_]+)\s*(?:\([^)]+\))?:\s*(.*)$", line)
+                    if match:
+                        param_descriptions[match.group(1)] = match.group(2)
+
+        properties = {}
+        required = []
+
+        for param_name, param in sig.parameters.items():
+            if param_name in ["self", "cls"]:
+                continue
+
+            param_type = type_hints.get(param_name, Any)
+            json_type = type_mapping.get(param_type, "string") # fallback to string
+
+            param_schema: Dict[str, Any] = {"type": json_type}
+            if param_name in param_descriptions:
+                param_schema["description"] = param_descriptions[param_name]
+
+            properties[param_name] = param_schema
+
+            if param.default is inspect.Parameter.empty:
+                required.append(param_name)
+
+        schema = {"type": "object", "properties": properties}
+        if required:
+            schema["required"] = required
+
+        return schema
 
     def execute(self, arguments_json: str) -> Any:
         """Executes the mapped callable with the provided JSON arguments.
@@ -256,14 +177,6 @@ class ToolSet():
         """Initializes a ToolSet instance."""
         self.tools = tools or []
 
-    def get_openai_schema(self) -> List[Dict[str, Any]]:
-        """Returns the list of tool definitions in OpenAI schema format."""
-        return [t.to_openai_schema() for t in self.tools]
-
-    def get_anthropic_schema(self) -> List[Dict[str, Any]]:
-        """Returns the list of tool definitions in Anthropic schema format."""
-        return [t.to_anthropic_schema() for t in self.tools]
-
     def __execute_one(self, func_name: str,
                      arguments_json: str) -> Tuple[bool, Any]:
         """Executes a single named tool with the given JSON arguments.
@@ -290,7 +203,7 @@ class ToolSet():
         return True, result
 
     def execute_tool_calls(
-        self, tool_calls: List['ToolCall']
+        self, tool_calls: List[ToolCall]
     ) -> Tuple[List[Any], Dict[str, bool]]:
         """Executes a list of tool calls.
 

--- a/ark/llm/tools/base.py
+++ b/ark/llm/tools/base.py
@@ -8,14 +8,24 @@
 @Contact:   https://github.com/SwordJack/
 """
 
-# Here put the import lib.
-from typing import Any, Callable, Dict, List, Optional
 from json import loads
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
 
 class FunctionToolParameter():
-    """Represents a parameter for a function tool."""
+    """Represents a parameter for a function tool.
 
-    def __init__(self, key: str, param_type: str, description: str, required: bool):
+    Attributes:
+        key: The technical key/name of the parameter.
+        param_type: The data type of the parameter (e.g., 'string', 'integer').
+        description: A brief description of what the parameter represents.
+        required: Whether the parameter must be provided by the LLM.
+        value: The current value assigned to this parameter.
+    """
+
+    def __init__(self, key: str, param_type: str, description: str,
+                 required: bool):
+        """Initializes a FunctionToolParameter instance."""
         self.key = key
         self.param_type = param_type
         self.description = description
@@ -24,66 +34,91 @@ class FunctionToolParameter():
 
     @property
     def name(self) -> str:
+        """Returns the technical name of the parameter."""
         return self.key
-    
+
     @name.setter
     def name(self, value: str):
+        """Sets the technical name of the parameter."""
         self.key = value
 
     @staticmethod
-    def parse_function_parameters(parameters_dict: dict) -> List['FunctionToolParameter']:
-        """Parses parameters information from a function definition dictionary."""
+    def parse_function_parameters(
+            parameters_dict: dict) -> List['FunctionToolParameter']:
+        """Parses parameter info from a function definition dictionary.
+
+        Args:
+            parameters_dict: The 'parameters' dictionary from a tool definition.
+
+        Returns:
+            A list of FunctionToolParameter instances.
+        """
         properties: Dict[str, dict] = parameters_dict.get("properties", {})
         required_params: list = parameters_dict.get("required", [])
-        
+
         parameters = []
         for key, value in properties.items():
             param_type = value.get("type", "string")
             description = value.get("description", "")
             required = (key in required_params)
-            parameters.append(FunctionToolParameter(
-                key=key, 
-                param_type=param_type, 
-                description=description, 
-                required=required
-            ))
+            parameters.append(
+                FunctionToolParameter(key=key,
+                                      param_type=param_type,
+                                      description=description,
+                                      required=required))
 
         return parameters
 
-class FunctionTool():
-    """Represents a tool that the LLM can call."""
 
-    def __init__(
-        self, 
-        tool_definition_dict: Dict[str, Any], 
-        tool_function_mapper: Dict[str, Callable] = None, 
-        tool_function_callable_kwargs: Dict[str, Any] = None
-    ):
-        """
-        Initializes a Function Tool.
-        
+class FunctionTool():
+    """Represents a tool that the LLM can call to perform actions.
+
+    Attributes:
+        tool_definition_dict: The original OpenAI-style tool definition.
+        name: The name of the function.
+        description: A brief description of the tool's purpose.
+        parameters: A list of parsed FunctionToolParameter objects.
+        mapped_callable: The Python function associated with this tool.
+        tool_function_callable_kwargs: Extra kwargs for the mapped callable.
+    """
+
+    def __init__(self,
+                 tool_definition_dict: Dict[str, Any],
+                 tool_function_mapper: Dict[str, Callable] = None,
+                 tool_function_callable_kwargs: Dict[str, Any] = None):
+        """Initializes a FunctionTool with a definition and a callable mapper.
+
         Args:
-            tool_definition_dict: The OpenAI-style tool definition.
-            tool_function_mapper: Map of function names to Python callables.
-            tool_function_callable_kwargs: Additional kwargs for the callables.
+            tool_definition_dict: The OpenAI-style tool definition dictionary.
+            tool_function_mapper: A map of tool names to Python callables.
+            tool_function_callable_kwargs: Static kwargs to pass to callables.
         """
         self.tool_definition_dict = tool_definition_dict
         function_dict = tool_definition_dict.get("function", {})
         self.name = function_dict.get("name", "")
         self.description = function_dict.get("description", "")
         self.parameters = FunctionToolParameter.parse_function_parameters(
-            function_dict.get("parameters", {})
-        )
-        
+            function_dict.get("parameters", {}))
+
         tool_function_mapper = tool_function_mapper or {}
         self.mapped_callable = tool_function_mapper.get(self.name)
         self.tool_function_callable_kwargs = tool_function_callable_kwargs or {}
 
     def execute(self, arguments_json: str) -> Any:
-        """Executes the mapped callable with the provided JSON arguments."""
+        """Executes the mapped callable with the provided JSON arguments.
+
+        Args:
+            arguments_json: A JSON string containing arguments from the LLM.
+
+        Returns:
+            The result of the callable execution, or an error message string.
+
+        Raises:
+            ValueError: If no callable is mapped for this tool.
+        """
         if not self.mapped_callable:
             raise ValueError(f"No callable mapped for tool: {self.name}")
-        
+
         try:
             args = loads(arguments_json)
             if self.tool_function_callable_kwargs:
@@ -92,6 +127,71 @@ class FunctionTool():
         except Exception as e:
             return f"Error executing tool '{self.name}': {e}"
 
-    def __str__(self):
-        callable_name = self.mapped_callable.__name__ if self.mapped_callable else "None"
-        return f"FunctionTool(name={self.name}, mapped_callable={callable_name})"
+    def __str__(self) -> str:
+        """Returns a string representation of the tool."""
+        callable_name = (self.mapped_callable.__name__
+                         if self.mapped_callable else "None")
+        return (f"FunctionTool(name={self.name}, "
+                f"mapped_callable={callable_name})")
+
+
+class ToolSet():
+    """Manages a collection of FunctionTools and orchestrates their execution.
+
+    Attributes:
+        tools: A list of managed FunctionTool instances.
+    """
+
+    def __init__(self, tools: List[FunctionTool] = None):
+        """Initializes a ToolSet instance."""
+        self.tools = tools or []
+
+    def get_openai_schema(self) -> List[Dict[str, Any]]:
+        """Returns the list of tool definitions in OpenAI schema format."""
+        return [t.tool_definition_dict for t in self.tools]
+
+    def execute_tool_calls(
+        self, tool_calls: List[Dict[str, Any]]
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, bool]]:
+        """Executes a list of tool calls and returns formatted messages.
+
+        Args:
+            tool_calls: A list of tool calls as returned by the LLM.
+
+        Returns:
+            A tuple containing:
+                - A list of response messages with the role 'tool'.
+                - A dictionary mapping tool names to their execution success.
+        """
+        messages = []
+        latest_results = {}
+
+        for tc in tool_calls:
+            func_name = tc["function"]["name"]
+            tool = next((t for t in self.tools if t.name == func_name), None)
+
+            if tool:
+                result = tool.execute(tc["function"]["arguments"])
+                # Handle (is_success, content) tuple or raw content string.
+                if isinstance(result, tuple) and len(result) == 2:
+                    is_success, tool_output = result
+                else:
+                    is_success, tool_output = True, str(result)
+
+                latest_results[func_name] = is_success
+            else:
+                tool_output = f"Tool '{func_name}' not found."
+                latest_results[func_name] = False
+
+            messages.append({
+                "tool_call_id": tc["id"],
+                "role": "tool",
+                "name": func_name,
+                "content": str(tool_output)
+            })
+
+        return messages, latest_results
+
+    def __bool__(self) -> bool:
+        """Returns True if the ToolSet contains at least one tool."""
+        return len(self.tools) > 0

--- a/ark/llm/tools/base.py
+++ b/ark/llm/tools/base.py
@@ -95,6 +95,3 @@ class FunctionTool():
     def __str__(self):
         callable_name = self.mapped_callable.__name__ if self.mapped_callable else "None"
         return f"FunctionTool(name={self.name}, mapped_callable={callable_name})"
-    
-    def __repr__(self):
-        return self.__str__()

--- a/ark/llm/tools/base.py
+++ b/ark/llm/tools/base.py
@@ -45,15 +45,22 @@ class FunctionTool:
                  tool_function_callable_kwargs: Dict[str, Any] = None):
         """Initializes a FunctionTool from neutral fields.
 
-        If ``parameters_schema`` is omitted, this attempts to auto-generate
-        the schema using `inspect.signature` and typing hints. It uses
-        best-effort parsing to extract parameter descriptions from the docstring.
+        While auto-generation of metadata (name, description, parameters_schema) is
+        the default behavior using Python's `inspect` and typing hints, developers
+        can explicitly pass these arguments to override and bypass the automatic
+        generation mechanism. This is useful for customizing or fine-tuning the tool
+        schema without modifying the underlying Python function, or when precise
+        JSON-Schema definition is required.
 
         Args:
             mapped_callable: The Python callable that backs this tool.
             name: The tool/function name (defaults to callable's name).
-            description: A human-readable description (defaults to first docstring line).
-            parameters_schema: The JSON-Schema inputs object.
+                  Explicitly passing this overrides the name.
+            description: A human-readable description (defaults to the first docstring line).
+                         Explicitly passing this overrides the description.
+            parameters_schema: The JSON-Schema inputs object. If omitted, this attempts to
+                               auto-generate the schema using `inspect.signature` and typing hints.
+                               Explicitly passing a dictionary overrides and bypasses auto-generation.
             tool_function_callable_kwargs: Static kwargs to pass to the callable.
         """
         self.mapped_callable = mapped_callable

--- a/ark/llm/tools/base.py
+++ b/ark/llm/tools/base.py
@@ -17,7 +17,10 @@ tool definition can move between providers without loss.
 """
 
 from json import loads
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from ark.llm.entities import ToolCall
 
 
 class FunctionToolParameter():
@@ -261,7 +264,7 @@ class ToolSet():
         """Returns the list of tool definitions in Anthropic schema format."""
         return [t.to_anthropic_schema() for t in self.tools]
 
-    def _execute_one(self, func_name: str,
+    def __execute_one(self, func_name: str,
                      arguments_json: str) -> Tuple[bool, Any]:
         """Executes a single named tool with the given JSON arguments.
 
@@ -287,76 +290,27 @@ class ToolSet():
         return True, result
 
     def execute_tool_calls(
-        self, tool_calls: List[Dict[str, Any]]
-    ) -> Tuple[List[Dict[str, Any]], Dict[str, bool]]:
-        """Executes tool calls and returns OpenAI ``role: "tool"`` messages.
+        self, tool_calls: List['ToolCall']
+    ) -> Tuple[List[Any], Dict[str, bool]]:
+        """Executes a list of tool calls.
 
         Args:
-            tool_calls: A list of standardized tool calls as returned by the LLM
-                (``[{"id", "type": "function", "function": {"name", "arguments"}}]``).
+            tool_calls: A list of ToolCall objects to execute.
 
         Returns:
             A tuple containing:
-                - A list of response messages with the role 'tool'.
+                - A list of execution results (raw outputs from the callables).
                 - A dictionary mapping tool names to their execution success.
         """
-        messages = []
+        results = []
         latest_results = {}
 
         for tc in tool_calls:
-            func_name = tc["function"]["name"]
-            is_success, tool_output = self._execute_one(
-                func_name, tc["function"]["arguments"])
-            latest_results[func_name] = is_success
+            is_success, tool_output = self.__execute_one(tc.name, tc.arguments)
+            latest_results[tc.name] = is_success
+            results.append(tool_output)
 
-            messages.append({
-                "tool_call_id": tc["id"],
-                "role": "tool",
-                "name": func_name,
-                "content": str(tool_output)
-            })
-
-        return messages, latest_results
-
-    def execute_tool_calls_anthropic(
-        self, tool_calls: List[Dict[str, Any]]
-    ) -> Tuple[List[Dict[str, Any]], Dict[str, bool]]:
-        """Executes tool calls and returns Anthropic ``tool_result`` blocks.
-
-        Accepts the same standardized tool-call shape as ``execute_tool_calls``
-        so both providers share one execution path; only the result formatting
-        differs. The returned blocks are meant to be wrapped in a single
-        ``{"role": "user", "content": [...]}`` message.
-
-        Args:
-            tool_calls: A list of standardized tool calls
-                (``[{"id", "type": "function", "function": {"name", "arguments"}}]``).
-
-        Returns:
-            A tuple containing:
-                - A list of ``tool_result`` content blocks (``is_error`` is set
-                  to ``True`` for failed executions).
-                - A dictionary mapping tool names to their execution success.
-        """
-        blocks = []
-        latest_results = {}
-
-        for tc in tool_calls:
-            func_name = tc["function"]["name"]
-            is_success, tool_output = self._execute_one(
-                func_name, tc["function"]["arguments"])
-            latest_results[func_name] = is_success
-
-            block: Dict[str, Any] = {
-                "type": "tool_result",
-                "tool_use_id": tc["id"],
-                "content": str(tool_output),
-            }
-            if not is_success:
-                block["is_error"] = True
-            blocks.append(block)
-
-        return blocks, latest_results
+        return results, latest_results
 
     def __bool__(self) -> bool:
         """Returns True if the ToolSet contains at least one tool."""

--- a/ark/llm/tools/base.py
+++ b/ark/llm/tools/base.py
@@ -2,6 +2,14 @@
 # -*- encoding: utf-8 -*-
 """Core logic for LLM tool/function calling.
 
+This module defines a provider-neutral representation of a callable tool.
+``FunctionTool`` holds the tool's name, description, and a JSON-Schema
+parameters object as its single source of truth, and renders that neutral
+representation into any vendor's wire format on demand
+(``to_openai_schema`` / ``to_anthropic_schema``). The matching ``from_*``
+classmethods ingest a vendor schema back into the neutral form, so a single
+tool definition can move between providers without loss.
+
 @File   :   base.py
 @Created:   2026/06/05 00:33
 @Author :   SwordJack
@@ -45,10 +53,10 @@ class FunctionToolParameter():
     @staticmethod
     def parse_function_parameters(
             parameters_dict: dict) -> List['FunctionToolParameter']:
-        """Parses parameter info from a function definition dictionary.
+        """Parses parameter info from a JSON-Schema parameters object.
 
         Args:
-            parameters_dict: The 'parameters' dictionary from a tool definition.
+            parameters_dict: A JSON-Schema object with ``properties``/``required``.
 
         Returns:
             A list of FunctionToolParameter instances.
@@ -71,38 +79,137 @@ class FunctionToolParameter():
 
 
 class FunctionTool():
-    """Represents a tool that the LLM can call to perform actions.
+    """A provider-neutral tool the LLM can call to perform actions.
+
+    The neutral core is ``name`` / ``description`` / ``parameters_schema`` (a
+    JSON-Schema object). Vendor wire formats are produced on demand via
+    ``to_openai_schema`` / ``to_anthropic_schema`` and ingested via the
+    ``from_*`` classmethods. Holding the full JSON-Schema object (rather than a
+    flattened parameter list) keeps details such as ``enum`` constraints and
+    nested object types intact across conversions.
 
     Attributes:
-        tool_definition_dict: The original OpenAI-style tool definition.
         name: The name of the function.
         description: A brief description of the tool's purpose.
-        parameters: A list of parsed FunctionToolParameter objects.
+        parameters_schema: The JSON-Schema object describing the inputs (the
+            shared inner shape used by both OpenAI and Anthropic).
         mapped_callable: The Python function associated with this tool.
         tool_function_callable_kwargs: Extra kwargs for the mapped callable.
     """
 
     def __init__(self,
-                 tool_definition_dict: Dict[str, Any],
-                 tool_function_mapper: Dict[str, Callable] = None,
+                 name: str,
+                 description: str = "",
+                 parameters_schema: Dict[str, Any] = None,
+                 mapped_callable: Optional[Callable] = None,
                  tool_function_callable_kwargs: Dict[str, Any] = None):
-        """Initializes a FunctionTool with a definition and a callable mapper.
+        """Initializes a FunctionTool from neutral fields.
 
         Args:
-            tool_definition_dict: The OpenAI-style tool definition dictionary.
+            name: The tool/function name.
+            description: A human-readable description of the tool.
+            parameters_schema: The JSON-Schema inputs object (defaults to an
+                empty object schema).
+            mapped_callable: The Python callable that backs this tool.
+            tool_function_callable_kwargs: Static kwargs to pass to the callable.
+        """
+        self.name = name
+        self.description = description
+        self.parameters_schema: Dict[str, Any] = (
+            parameters_schema or {"type": "object", "properties": {}})
+        self.mapped_callable = mapped_callable
+        self.tool_function_callable_kwargs = tool_function_callable_kwargs or {}
+
+    @property
+    def parameters(self) -> List[FunctionToolParameter]:
+        """Returns the parameters parsed from ``parameters_schema`` on demand."""
+        return FunctionToolParameter.parse_function_parameters(
+            self.parameters_schema)
+
+    @classmethod
+    def from_openai_schema(
+            cls,
+            tool_definition_dict: Dict[str, Any],
+            tool_function_mapper: Dict[str, Callable] = None,
+            tool_function_callable_kwargs: Dict[str, Any] = None
+    ) -> 'FunctionTool':
+        """Builds a FunctionTool from an OpenAI-style tool definition.
+
+        Args:
+            tool_definition_dict: OpenAI ``{"type": "function", "function": {...}}``.
             tool_function_mapper: A map of tool names to Python callables.
             tool_function_callable_kwargs: Static kwargs to pass to callables.
-        """
-        self.tool_definition_dict = tool_definition_dict
-        function_dict = tool_definition_dict.get("function", {})
-        self.name = function_dict.get("name", "")
-        self.description = function_dict.get("description", "")
-        self.parameters = FunctionToolParameter.parse_function_parameters(
-            function_dict.get("parameters", {}))
 
-        tool_function_mapper = tool_function_mapper or {}
-        self.mapped_callable = tool_function_mapper.get(self.name)
-        self.tool_function_callable_kwargs = tool_function_callable_kwargs or {}
+        Returns:
+            A FunctionTool instance.
+        """
+        function_dict = tool_definition_dict.get("function", {})
+        name = function_dict.get("name", "")
+        return cls(
+            name=name,
+            description=function_dict.get("description", ""),
+            parameters_schema=function_dict.get("parameters"),
+            mapped_callable=(tool_function_mapper or {}).get(name),
+            tool_function_callable_kwargs=tool_function_callable_kwargs,
+        )
+
+    @classmethod
+    def from_anthropic_schema(
+            cls,
+            tool_definition_dict: Dict[str, Any],
+            tool_function_mapper: Dict[str, Callable] = None,
+            tool_function_callable_kwargs: Dict[str, Any] = None
+    ) -> 'FunctionTool':
+        """Builds a FunctionTool from an Anthropic-style tool definition.
+
+        Args:
+            tool_definition_dict: Anthropic ``{"name", "description", "input_schema"}``.
+            tool_function_mapper: A map of tool names to Python callables.
+            tool_function_callable_kwargs: Static kwargs to pass to callables.
+
+        Returns:
+            A FunctionTool instance.
+        """
+        name = tool_definition_dict.get("name", "")
+        return cls(
+            name=name,
+            description=tool_definition_dict.get("description", ""),
+            parameters_schema=tool_definition_dict.get("input_schema"),
+            mapped_callable=(tool_function_mapper or {}).get(name),
+            tool_function_callable_kwargs=tool_function_callable_kwargs,
+        )
+
+    def to_openai_schema(self) -> Dict[str, Any]:
+        """Renders this tool as an OpenAI-style tool definition.
+
+        Returns:
+            An OpenAI ``{"type": "function", "function": {...}}`` dictionary.
+        """
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters_schema,
+            },
+        }
+
+    def to_anthropic_schema(self) -> Dict[str, Any]:
+        """Renders this tool as an Anthropic-style tool definition.
+
+        Returns:
+            An Anthropic ``{"name", "description", "input_schema"}`` dictionary.
+            ``input_schema`` always carries ``"type": "object"`` as Anthropic
+            requires.
+        """
+        schema = self.parameters_schema
+        if "type" not in schema:
+            schema = {**schema, "type": "object"}
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": schema,
+        }
 
     def execute(self, arguments_json: str) -> Any:
         """Executes the mapped callable with the provided JSON arguments.
@@ -148,15 +255,45 @@ class ToolSet():
 
     def get_openai_schema(self) -> List[Dict[str, Any]]:
         """Returns the list of tool definitions in OpenAI schema format."""
-        return [t.tool_definition_dict for t in self.tools]
+        return [t.to_openai_schema() for t in self.tools]
+
+    def get_anthropic_schema(self) -> List[Dict[str, Any]]:
+        """Returns the list of tool definitions in Anthropic schema format."""
+        return [t.to_anthropic_schema() for t in self.tools]
+
+    def _execute_one(self, func_name: str,
+                     arguments_json: str) -> Tuple[bool, Any]:
+        """Executes a single named tool with the given JSON arguments.
+
+        This is the provider-neutral execution core shared by all
+        ``execute_tool_calls_*`` formatters.
+
+        Args:
+            func_name: The name of the tool to execute.
+            arguments_json: A JSON string of arguments from the LLM.
+
+        Returns:
+            A tuple of ``(is_success, tool_output)``. ``tool_output`` is the
+            raw callable result (or an error message when the tool is missing).
+        """
+        tool = next((t for t in self.tools if t.name == func_name), None)
+        if tool is None:
+            return False, f"Tool '{func_name}' not found."
+
+        result = tool.execute(arguments_json)
+        # Handle (is_success, content) tuple or raw content.
+        if isinstance(result, tuple) and len(result) == 2:
+            return result[0], result[1]
+        return True, result
 
     def execute_tool_calls(
         self, tool_calls: List[Dict[str, Any]]
     ) -> Tuple[List[Dict[str, Any]], Dict[str, bool]]:
-        """Executes a list of tool calls and returns formatted messages.
+        """Executes tool calls and returns OpenAI ``role: "tool"`` messages.
 
         Args:
-            tool_calls: A list of tool calls as returned by the LLM.
+            tool_calls: A list of standardized tool calls as returned by the LLM
+                (``[{"id", "type": "function", "function": {"name", "arguments"}}]``).
 
         Returns:
             A tuple containing:
@@ -168,20 +305,9 @@ class ToolSet():
 
         for tc in tool_calls:
             func_name = tc["function"]["name"]
-            tool = next((t for t in self.tools if t.name == func_name), None)
-
-            if tool:
-                result = tool.execute(tc["function"]["arguments"])
-                # Handle (is_success, content) tuple or raw content string.
-                if isinstance(result, tuple) and len(result) == 2:
-                    is_success, tool_output = result
-                else:
-                    is_success, tool_output = True, str(result)
-
-                latest_results[func_name] = is_success
-            else:
-                tool_output = f"Tool '{func_name}' not found."
-                latest_results[func_name] = False
+            is_success, tool_output = self._execute_one(
+                func_name, tc["function"]["arguments"])
+            latest_results[func_name] = is_success
 
             messages.append({
                 "tool_call_id": tc["id"],
@@ -191,6 +317,46 @@ class ToolSet():
             })
 
         return messages, latest_results
+
+    def execute_tool_calls_anthropic(
+        self, tool_calls: List[Dict[str, Any]]
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, bool]]:
+        """Executes tool calls and returns Anthropic ``tool_result`` blocks.
+
+        Accepts the same standardized tool-call shape as ``execute_tool_calls``
+        so both providers share one execution path; only the result formatting
+        differs. The returned blocks are meant to be wrapped in a single
+        ``{"role": "user", "content": [...]}`` message.
+
+        Args:
+            tool_calls: A list of standardized tool calls
+                (``[{"id", "type": "function", "function": {"name", "arguments"}}]``).
+
+        Returns:
+            A tuple containing:
+                - A list of ``tool_result`` content blocks (``is_error`` is set
+                  to ``True`` for failed executions).
+                - A dictionary mapping tool names to their execution success.
+        """
+        blocks = []
+        latest_results = {}
+
+        for tc in tool_calls:
+            func_name = tc["function"]["name"]
+            is_success, tool_output = self._execute_one(
+                func_name, tc["function"]["arguments"])
+            latest_results[func_name] = is_success
+
+            block: Dict[str, Any] = {
+                "type": "tool_result",
+                "tool_use_id": tc["id"],
+                "content": str(tool_output),
+            }
+            if not is_success:
+                block["is_error"] = True
+            blocks.append(block)
+
+        return blocks, latest_results
 
     def __bool__(self) -> bool:
         """Returns True if the ToolSet contains at least one tool."""

--- a/ark/llm/tools/base.py
+++ b/ark/llm/tools/base.py
@@ -1,0 +1,100 @@
+#! python3
+# -*- encoding: utf-8 -*-
+"""Core logic for LLM tool/function calling.
+
+@File   :   base.py
+@Created:   2026/06/05 00:33
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+# Here put the import lib.
+from typing import Any, Callable, Dict, List, Optional
+from json import loads
+
+class FunctionToolParameter():
+    """Represents a parameter for a function tool."""
+
+    def __init__(self, key: str, param_type: str, description: str, required: bool):
+        self.key = key
+        self.param_type = param_type
+        self.description = description
+        self.required = required
+        self.value: Any = None
+
+    @property
+    def name(self) -> str:
+        return self.key
+    
+    @name.setter
+    def name(self, value: str):
+        self.key = value
+
+    @staticmethod
+    def parse_function_parameters(parameters_dict: dict) -> List['FunctionToolParameter']:
+        """Parses parameters information from a function definition dictionary."""
+        properties: Dict[str, dict] = parameters_dict.get("properties", {})
+        required_params: list = parameters_dict.get("required", [])
+        
+        parameters = []
+        for key, value in properties.items():
+            param_type = value.get("type", "string")
+            description = value.get("description", "")
+            required = (key in required_params)
+            parameters.append(FunctionToolParameter(
+                key=key, 
+                param_type=param_type, 
+                description=description, 
+                required=required
+            ))
+
+        return parameters
+
+class FunctionTool():
+    """Represents a tool that the LLM can call."""
+
+    def __init__(
+        self, 
+        tool_definition_dict: Dict[str, Any], 
+        tool_function_mapper: Dict[str, Callable] = None, 
+        tool_function_callable_kwargs: Dict[str, Any] = None
+    ):
+        """
+        Initializes a Function Tool.
+        
+        Args:
+            tool_definition_dict: The OpenAI-style tool definition.
+            tool_function_mapper: Map of function names to Python callables.
+            tool_function_callable_kwargs: Additional kwargs for the callables.
+        """
+        self.tool_definition_dict = tool_definition_dict
+        function_dict = tool_definition_dict.get("function", {})
+        self.name = function_dict.get("name", "")
+        self.description = function_dict.get("description", "")
+        self.parameters = FunctionToolParameter.parse_function_parameters(
+            function_dict.get("parameters", {})
+        )
+        
+        tool_function_mapper = tool_function_mapper or {}
+        self.mapped_callable = tool_function_mapper.get(self.name)
+        self.tool_function_callable_kwargs = tool_function_callable_kwargs or {}
+
+    def execute(self, arguments_json: str) -> Any:
+        """Executes the mapped callable with the provided JSON arguments."""
+        if not self.mapped_callable:
+            raise ValueError(f"No callable mapped for tool: {self.name}")
+        
+        try:
+            args = loads(arguments_json)
+            if self.tool_function_callable_kwargs:
+                args.update(self.tool_function_callable_kwargs)
+            return self.mapped_callable(**args)
+        except Exception as e:
+            return f"Error executing tool '{self.name}': {e}"
+
+    def __str__(self):
+        callable_name = self.mapped_callable.__name__ if self.mapped_callable else "None"
+        return f"FunctionTool(name={self.name}, mapped_callable={callable_name})"
+    
+    def __repr__(self):
+        return self.__str__()

--- a/ark/utils/__init__.py
+++ b/ark/utils/__init__.py
@@ -1,0 +1,13 @@
+#! python3
+# -*- encoding: utf-8 -*-
+"""
+@File   :   __init__.py
+@Created:   2026/06/06 00:16
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+# Here put the import lib.
+from .json_fixer import JsonFixer
+
+__all__ = ["JsonFixer"]

--- a/ark/utils/json_fixer.py
+++ b/ark/utils/json_fixer.py
@@ -1,0 +1,348 @@
+#! python3
+# -*- encoding: utf-8 -*-
+"""
+@File   :   json_fixer_service.py
+@Created:   2025/10/19 13:50
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+# Here put the import lib.
+import json
+import re
+import ast
+from typing import List, Optional, Tuple, Any
+
+
+class JsonFixer:
+    """
+    A robust JSON fixer that extracts, cleans, and repairs broken or noisy JSON-like text.
+    Public API: `JsonFixer.clean_and_fix_json(text: str) -> str`
+    """
+
+    # --- Precompiled regular expressions (performance + readability) ---
+    FENCE_RE = re.compile(r"```(?:json)?\s*([\s\S]*?)```", flags=re.IGNORECASE)
+    OPEN_BRACE_RE = re.compile(r'\{')
+    OPEN_BRACKET_RE = re.compile(r'\[')
+    CLOSE_BRACE_RE = re.compile(r'\}')
+    CLOSE_BRACKET_RE = re.compile(r'\]')
+    TRAILING_COMMA_RE = re.compile(r',\s*([}\]])')
+    EQUALS_AS_COLON_RE = re.compile(
+        r'(?P<key>(?P<q>"[^"]*"|\'[^\']*\')|(?P<u>[A-Za-z_][A-Za-z0-9_\-]*))\s*=\s*'
+    )
+    UNQUOTED_KEYS_RE = re.compile(r'(?P<prefix>[{\s,])(?P<key>[A-Za-z_][A-Za-z0-9_\-]*)\s*:')
+    JSON_TO_PY_RE = re.compile(r'\b(true|false|null)\b')
+    PY_TO_JSON_RE = re.compile(r'\b(True|False|None)\b')
+    SINGLE_QUOTED_STRING_RE = re.compile(r"'([^'\\]*(?:\\.[^'\\]*)*)'")
+    FIRST_BRACE_OR_BRACKET_RE = re.compile(r'[\{\[]', re.DOTALL)
+    LAST_ANY_RE = re.compile(r'.*[\}\]]', re.DOTALL)
+    ZERO_WIDTH_RE = re.compile(r'[\u200b-\u200f\u202a-\u202e]')
+    
+    # Matches single backticks that are not part of a triple-backtick sequence.
+    SINGLE_BACKTICK_RE = re.compile(r'(?<!`)`(?!`)')
+    # Heuristically matches unescaped double quotes inside string values.
+    UNESCAPED_QUOTE_RE = re.compile(r'(?<=[^\s:,\[{])"(?=[^\s:,\]}])')
+
+    # ========================= Public API =========================
+
+    @classmethod
+    def clean_and_fix_json(cls, text: str) -> str:
+        """
+        Input: Raw LLM output (expected to include a JSON object/array, possibly with noise).
+        Output: Canonical, minimal JSON string (UTF-8, no spaces): separators=(',', ':'), ensure_ascii=False.
+
+        Strategy:
+        - Normalize the text (quotes, backticks, invisible chars).
+        - Extract candidate JSON regions (code fences, broad slice from first '{'/'[' to last '}'/']', full text).
+        - For each candidate, attempt multi-stage repairs and parse.
+        - If all candidates fail, run a final brute-force repair on the full text.
+        - Raises ValueError if no valid JSON can be recovered.
+        """
+        normalized = cls._normalize_basic(text)
+        candidates = cls._extract_candidates(normalized)
+
+        last_error: Optional[Exception] = None
+
+        for cand in candidates:
+            cand_norm = cls._normalize_basic(cand)
+
+            # Trim to a likely JSON substring (from first { or [)
+            first = cls.FIRST_BRACE_OR_BRACKET_RE.search(cand_norm)
+            last = cls.LAST_ANY_RE.search(cand_norm)
+            if first and last:
+                cand_norm = cand_norm[first.start():]
+
+            obj, err = cls._try_parse_variants(cand_norm)
+            # Enforce that the evaluated object is a structured JSON type (dict or list),
+            # preventing ast.literal_eval from mistakenly passing pure string evaluations.
+            if obj is not None and isinstance(obj, (dict, list)):
+                try:
+                    return json.dumps(obj, ensure_ascii=False, separators=(',', ':'))
+                except Exception as e:
+                    last_error = e
+                    continue
+            else:
+                last_error = err
+
+        # Final fallback: brute-force repair over the entire normalized text
+        brutal = cls._single_to_double_quotes(
+            cls._quote_unquoted_keys(
+                cls._fix_equals_as_colon(
+                    cls._strip_trailing_commas(cls._balance_brackets(normalized))
+                )
+            )
+        )
+        obj, err = cls._try_parse_variants(brutal)
+        if obj is not None and isinstance(obj, (dict, list)):
+            return json.dumps(obj, ensure_ascii=False, separators=(',', ':'))
+
+        raise ValueError(f"Failed to extract and repair a valid JSON object. Input Content: {text}; Last error: {last_error}")
+
+    # ========================= Parsing pipeline =========================
+
+    @classmethod
+    def _try_parse_variants(cls, s: str) -> Tuple[Optional[Any], Optional[Exception]]:
+        """
+        Try multiple repair/parse strategies. Returns (obj, None) on success or (None, last_err) on failure.
+        Order of attempts mirrors common LLM mistakes and cheapest-to-most-invasive fixes.
+        """
+        last_err: Optional[Exception] = None
+
+        # Attempt 0: Direct JSON
+        try:
+            return json.loads(s), None
+        except Exception as e:
+            last_err = e
+
+        # Attempt 1: Balance brackets + strip trailing commas -> JSON
+        s1 = cls._strip_trailing_commas(cls._balance_brackets(s))
+        try:
+            return json.loads(s1), None
+        except Exception as e:
+            last_err = e
+
+        # Attempt 2: Fix "key" = value, quote unquoted keys, strip trailing commas -> JSON
+        s2 = cls._fix_equals_as_colon(s1)
+        s2 = cls._quote_unquoted_keys(s2)
+        s2 = cls._strip_trailing_commas(s2)
+        try:
+            return json.loads(s2), None
+        except Exception as e:
+            last_err = e
+
+        # Attempt 2.1: Heuristic escape of internal unescaped quotes -> JSON
+        # This fixes issues like: "review": "He said "hello" today."
+        s_esc = cls._escape_internal_quotes(s2)
+        try:
+            return json.loads(s_esc), None
+        except Exception as e:
+            last_err = e
+
+        # Attempt 3: Convert single-quoted strings to double-quoted -> JSON
+        s3 = cls._single_to_double_quotes(s2)
+        s3 = cls._strip_trailing_commas(s3)
+        try:
+            return json.loads(s3), None
+        except Exception as e:
+            last_err = e
+
+        # Attempt 4: Python literal_eval (tolerates single quotes and True/False/None)
+        s4 = cls._to_python_bools_nulls(s2)
+        try:
+            obj = ast.literal_eval(s4)
+            return obj, None
+        except Exception as e:
+            last_err = e
+
+        # Attempt 5: literal_eval on single-quote-fixed string
+        s5 = cls._to_python_bools_nulls(s3)
+        try:
+            obj = ast.literal_eval(s5)
+            return obj, None
+        except Exception as e:
+            last_err = e
+
+        return None, last_err
+
+    # ========================= Normalization & extraction =========================
+
+    @classmethod
+    def _normalize_basic(cls, s: str) -> str:
+        """Remove BOM/zero-width chars, normalize smart quotes, safely replace backticks, and tidy spaces."""
+        s = s.replace('\ufeff', '')
+        # 将中文弯引号（" "）转为直角引号（「 」），避免与 JSON 结构引号冲突
+        s = s.replace('\u201c', '\u300c').replace('\u201d', '\u300d')
+        s = s.replace('\u2018', "'").replace('\u2019', "'")
+        s = s.replace('\u00a0', ' ')
+
+        # Replace single backticks to double quotes, but protect Markdown code fences (```).
+        s = cls.SINGLE_BACKTICK_RE.sub('"', s)
+        s = cls.ZERO_WIDTH_RE.sub('', s)
+        return s
+
+    @classmethod
+    def _extract_candidates(cls, s: str) -> List[str]:
+        """
+        Gather candidate JSON substrings, ordered by likelihood:
+        1) Markdown fenced blocks
+        2) Slice from first '{'/'[' to last '}'/']'
+        3) Whole text
+        Deduplicated while preserving order.
+        """
+        cands: List[str] = []
+
+        # Fenced code blocks (```json ... ``` or ``` ... ```)
+        for blk in cls.FENCE_RE.findall(s):
+            cands.append(blk.strip())
+
+        # Slice between first opening and last closing bracket/brace
+        opens = [m.start() for m in cls.OPEN_BRACE_RE.finditer(s)] + [m.start() for m in cls.OPEN_BRACKET_RE.finditer(s)]
+        closes = [m.start() for m in cls.CLOSE_BRACE_RE.finditer(s)] + [m.start() for m in cls.CLOSE_BRACKET_RE.finditer(s)]
+        if opens and closes:
+            start = min(opens)
+            end = max(closes)
+            if start < end:
+                cands.append(s[start:end + 1].strip())
+
+        # Full text as fallback
+        cands.append(s.strip())
+
+        # Deduplicate while preserving order
+        seen = set()
+        uniq: List[str] = []
+        for x in cands:
+            if x and x not in seen:
+                seen.add(x)
+                uniq.append(x)
+        return uniq
+
+    # ========================= Structural fixes =========================
+
+    @classmethod
+    def _balance_brackets(cls, s: str) -> str:
+        """
+        Best-effort bracket/brace repair with ordering correction.
+        - Streams through the input, maintaining a stack of openings.
+        - On a mismatched closing (e.g., '}' while top is '['), it first emits the
+        needed closing (']') to close the current top, then re-checks the incoming
+        closing. If it now matches, it consumes it; otherwise the stray closing is dropped.
+        - Finally, appends any remaining required closings.
+        This is safer than simply appending all missing closings at the end.
+        """
+        pairs = {'{': '}', '[': ']'}
+        opening = set(pairs.keys())
+        closing = set(pairs.values())
+
+        stack = []
+        out_chars = []
+
+        for ch in s:
+            if ch in opening:
+                stack.append(ch)
+                out_chars.append(ch)
+            elif ch in closing:
+                if stack and pairs[stack[-1]] == ch:
+                    # normal match
+                    stack.pop()
+                    out_chars.append(ch)
+                else:
+                    # mismatched closing: close what's actually open first
+                    while stack and pairs[stack[-1]] != ch:
+                        out_chars.append(pairs[stack.pop()])
+                    if stack and pairs[stack[-1]] == ch:
+                        stack.pop()
+                        out_chars.append(ch)
+                    else:
+                        # stray unmatched closing: drop it (safer than inserting an opener)
+                        # pass
+                        continue
+            else:
+                out_chars.append(ch)
+
+        # close any remaining openings
+        while stack:
+            out_chars.append(pairs[stack.pop()])
+
+        return ''.join(out_chars)
+
+    @classmethod
+    def _strip_trailing_commas(cls, s: str) -> str:
+        """Remove trailing commas before a closing '}' or ']'."""
+        return cls.TRAILING_COMMA_RE.sub(r'\1', s)
+
+    @classmethod
+    def _fix_equals_as_colon(cls, s: str) -> str:
+        """
+        Turn key=value into "key": value.
+        - If the key is quoted already ("key" or 'key'), keep it and replace '=' with ':'.
+        - If the key is an unquoted identifier (foo), wrap it with double quotes.
+        """
+        def repl(m: re.Match) -> str:
+            q = m.group('q')   # quoted key if present
+            u = m.group('u')   # unquoted identifier key if present
+            if q is not None:
+                # Keep the quoted key as-is, just replace '=' with ':'
+                return f'{q}: '
+            else:
+                # Add quotes for the unquoted identifier key
+                return f'"{u}": '
+        return cls.EQUALS_AS_COLON_RE.sub(repl, s)
+
+    @classmethod
+    def _quote_unquoted_keys(cls, s: str) -> str:
+        """
+        Quote unquoted object keys: `{foo: 1}` → `{"foo": 1}`.
+        Only matches keys that look like identifiers and are followed by a colon.
+        """
+        return cls.UNQUOTED_KEYS_RE.sub(cls._quote_unquoted_keys_repl, s)
+
+    @classmethod
+    def _quote_unquoted_keys_repl(cls, m: re.Match) -> str:
+        return f'{m.group("prefix")}"{m.group("key")}":'
+
+    @classmethod
+    def _escape_internal_quotes(cls, s: str) -> str:
+        """
+        Heuristically escape unescaped double quotes inside string values.
+        Matches a double quote that is surrounded by non-boundary characters.
+        """
+        return cls.UNESCAPED_QUOTE_RE.sub(r'\"', s)
+
+    # ========================= Token conversions =========================
+
+    @classmethod
+    def _to_python_bools_nulls(cls, s: str) -> str:
+        """Convert JSON true/false/null to Python True/False/None (for literal_eval)."""
+        return cls.JSON_TO_PY_RE.sub(cls._to_python_bools_nulls_repl, s)
+
+    @classmethod
+    def _to_python_bools_nulls_repl(cls, m: re.Match) -> str:
+        word = m.group(0)
+        return {'true': 'True', 'false': 'False', 'null': 'None'}[word]
+
+    @classmethod
+    def _to_json_bools_nulls(cls, s: str) -> str:
+        """Convert Python True/False/None to JSON true/false/null (utility, not required in main flow)."""
+        return cls.PY_TO_JSON_RE.sub(cls._to_json_bools_nulls_repl, s)
+
+    @classmethod
+    def _to_json_bools_nulls_repl(cls, m: re.Match) -> str:
+        word = m.group(0)
+        return {'True': 'true', 'False': 'false', 'None': 'null'}[word]
+
+    # ========================= Quote normalization =========================
+
+    @classmethod
+    def _single_to_double_quotes(cls, s: str) -> str:
+        """
+        Convert single-quoted strings to double-quoted strings (conservative heuristic).
+        This is NOT a full JSON parser; it targets common LLM outputs.
+        """
+        return cls.SINGLE_QUOTED_STRING_RE.sub(cls._single_to_double_quotes_repl, s)
+
+    @classmethod
+    def _single_to_double_quotes_repl(cls, m: re.Match) -> str:
+        inner = m.group(1)
+        inner = inner.replace('\\"', '"')   # Unescape existing double quotes
+        inner = inner.replace('"', '\\"')   # Escape new double quotes
+        return f'"{inner}"'

--- a/environment.yml
+++ b/environment.yml
@@ -5,26 +5,44 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=main
   - _openmp_mutex=5.1=1_gnu
+  - _python_abi3_support=1.0=hd8ed1ab_2
+  - annotated-doc=0.0.4=pyhcf101f3_0
   - annotated-types=0.6.0=py313h06a4308_1
+  - anthropic=0.85.0=pyhd8ed1ab_0
   - anyio=4.12.1=py313h06a4308_0
   - aom=3.13.2=h664349e_0
+  - brotli-python=1.2.0=py313hf159716_1
   - bzip2=1.0.8=h5eee18b_6
-  - ca-certificates=2026.5.14=h06a4308_0
+  - ca-certificates=2026.5.20=hbd8a1cb_0
+  - cached-property=1.5.2=hd8ed1ab_1
+  - cached_property=1.5.2=pyha770c72_1
   - cairo=1.18.4=h44eff21_0
-  - certifi=2026.5.20=py313h06a4308_0
+  - certifi=2026.5.20=pyhd8ed1ab_0
+  - cffi=1.17.1=py313hfab6e84_0
+  - charset-normalizer=3.4.7=pyhd8ed1ab_0
+  - click=8.4.1=pyhc90fa1f_0
   - colorlog=6.9.0=pyh707e725_1
+  - cpython=3.13.13=py313hd8ed1ab_100
   - dav1d=1.5.3=h3e43c27_0
   - distro=1.9.0=py313h06a4308_0
+  - docstring_parser=0.18.0=pyhd8ed1ab_0
   - expat=2.6.4=h6a678d5_0
+  - filelock=3.29.1=pyhd8ed1ab_0
   - fontconfig=2.14.1=h55d465d_3
   - freetype=2.14.1=hf5b9546_0
   - fribidi=1.0.16=h10f3c28_1
+  - fsspec=2026.4.0=pyhd8ed1ab_0
   - graphite2=1.3.14=h295c915_1
   - greenlet=3.1.1=py313h6a678d5_0
   - h11=0.16.0=py313h06a4308_1
+  - h2=4.3.0=pyhcf101f3_0
   - harfbuzz=12.3.0=h79d275a_1
+  - hf-xet=1.5.0=py310hb823017_0
+  - hpack=4.1.0=pyhd8ed1ab_0
   - httpcore=1.0.9=py313h06a4308_0
   - httpx=0.28.1=py313h06a4308_1
+  - huggingface_hub=1.18.0=pyhd8ed1ab_0
+  - hyperframe=6.1.0=pyhd8ed1ab_0
   - icu=73.1=h6a678d5_0
   - idna=3.18=py313h06a4308_0
   - iniconfig=1.1.1=pyhd3eb1b0_0
@@ -52,9 +70,11 @@ dependencies:
   - libxcb=1.17.0=h9b100fa_0
   - libxml2=2.13.9=h2c43086_0
   - lz4-c=1.9.4=h6a678d5_1
+  - markdown-it-py=4.2.0=pyhd8ed1ab_0
+  - mdurl=0.1.2=pyhd8ed1ab_1
   - ncurses=6.4=h6a678d5_0
   - openai=2.30.0=py313h06a4308_0
-  - openssl=3.5.6=h1b28b03_0
+  - openssl=3.6.2=h35e630c_0
   - packaging=24.2=py313h06a4308_0
   - pcre2=10.46=hf426167_0
   - phonenumbers=8.13.49=py313h06a4308_0
@@ -64,22 +84,33 @@ dependencies:
   - pluggy=1.5.0=py313h06a4308_0
   - pthread-stubs=0.3=h0ce48e5_1
   - pycountry=24.6.1=pyhd8ed1ab_0
+  - pycparser=3.0=pyhcf101f3_0
   - pydantic=2.11.9=py313h06a4308_0
   - pydantic-core=2.33.2=py313hc6f7160_0
+  - pygments=2.20.0=pyhd8ed1ab_0
+  - pysocks=1.7.1=pyha55dd90_7
   - pytest=8.3.4=py313h06a4308_0
   - python=3.13.2=hf623796_100_cp313
+  - python-gil=3.13.13=h4df99d1_100
   - python_abi=3.13=0_cp313
+  - pyyaml=6.0.3=py313h3dea7bd_1
   - readline=8.2=h5eee18b_0
+  - requests=2.34.2=pyhcf101f3_0
+  - rich=15.0.0=pyhcf101f3_0
   - setuptools=75.8.0=py313h06a4308_0
+  - shellingham=1.5.4=pyhd8ed1ab_2
   - sniffio=1.3.1=py313h06a4308_0
   - sqlalchemy=2.0.37=py313h00e1ef3_0
   - sqlite=3.45.3=h5eee18b_0
   - tk=8.6.14=h39e8969_0
+  - tokenizers=0.22.2=py313h4d6fefd_0
   - tqdm=4.67.3=py313h7040dfc_1
+  - typer=0.25.1=pyhcf101f3_0
   - typing-extensions=4.12.2=py313h06a4308_0
   - typing-inspection=0.4.2=py313h06a4308_0
   - typing_extensions=4.12.2=py313h06a4308_0
   - tzdata=2025a=h04d1e81_0
+  - urllib3=2.5.0=pyhd8ed1ab_0
   - wheel=0.45.1=py313h06a4308_0
   - xorg-libx11=1.8.12=h9b100fa_1
   - xorg-libxau=1.0.12=h9b100fa_0
@@ -88,5 +119,7 @@ dependencies:
   - xorg-libxrender=0.9.12=h9b100fa_0
   - xorg-xorgproto=2024.1=h5eee18b_1
   - xz=5.6.4=h5eee18b_1
+  - yaml=0.2.5=h280c20c_3
   - zlib=1.2.13=h5eee18b_1
+  - zstandard=0.23.0=py313h07c4f96_3
   - zstd=1.5.6=hc292b87_0

--- a/environment.yml
+++ b/environment.yml
@@ -7,34 +7,62 @@ dependencies:
   - _openmp_mutex=5.1=1_gnu
   - annotated-types=0.6.0=py313h06a4308_1
   - anyio=4.12.1=py313h06a4308_0
+  - aom=3.13.2=h664349e_0
   - bzip2=1.0.8=h5eee18b_6
   - ca-certificates=2026.5.14=h06a4308_0
+  - cairo=1.18.4=h44eff21_0
   - certifi=2026.5.20=py313h06a4308_0
   - colorlog=6.9.0=pyh707e725_1
+  - dav1d=1.5.3=h3e43c27_0
   - distro=1.9.0=py313h06a4308_0
   - expat=2.6.4=h6a678d5_0
+  - fontconfig=2.14.1=h55d465d_3
+  - freetype=2.14.1=hf5b9546_0
+  - fribidi=1.0.16=h10f3c28_1
+  - graphite2=1.3.14=h295c915_1
   - greenlet=3.1.1=py313h6a678d5_0
   - h11=0.16.0=py313h06a4308_1
+  - harfbuzz=12.3.0=h79d275a_1
   - httpcore=1.0.9=py313h06a4308_0
   - httpx=0.28.1=py313h06a4308_1
+  - icu=73.1=h6a678d5_0
   - idna=3.18=py313h06a4308_0
   - iniconfig=1.1.1=pyhd3eb1b0_0
   - jiter=0.12.0=py313h498d7c9_0
+  - jpeg=9f=h5ce9db8_0
+  - lcms2=2.19=he283960_0
   - ld_impl_linux-64=2.40=h12ee557_0
+  - lerc=4.1.0=h7354ed3_2
+  - libavif=1.3.0=h2b90b00_1
+  - libdeflate=1.22=h5eee18b_0
   - libffi=3.4.4=h6a678d5_1
   - libgcc=14.2.0=h767d61c_2
   - libgcc-ng=14.2.0=h69a702a_2
+  - libglib=2.86.3=h8b17d9a_0
   - libgomp=14.2.0=h767d61c_2
+  - libiconv=1.18=h75a1612_0
   - libmpdec=4.0.0=h5eee18b_0
+  - libopenjpeg=2.5.4=hee96239_1
+  - libpng=1.6.54=hee55ce4_0
+  - libstdcxx=14.2.0=h8f9b012_2
   - libstdcxx-ng=11.2.0=h1234567_1
+  - libtiff=4.7.1=h029b1ac_0
   - libuuid=1.41.5=h5eee18b_0
+  - libwebp-base=1.6.0=hb7bb969_0
+  - libxcb=1.17.0=h9b100fa_0
+  - libxml2=2.13.9=h2c43086_0
+  - lz4-c=1.9.4=h6a678d5_1
   - ncurses=6.4=h6a678d5_0
   - openai=2.30.0=py313h06a4308_0
   - openssl=3.5.6=h1b28b03_0
   - packaging=24.2=py313h06a4308_0
+  - pcre2=10.46=hf426167_0
   - phonenumbers=8.13.49=py313h06a4308_0
+  - pillow=12.1.0=py313hd9fd23a_0
   - pip=25.0=py313h06a4308_0
+  - pixman=0.46.4=h7934f7d_0
   - pluggy=1.5.0=py313h06a4308_0
+  - pthread-stubs=0.3=h0ce48e5_1
   - pycountry=24.6.1=pyhd8ed1ab_0
   - pydantic=2.11.9=py313h06a4308_0
   - pydantic-core=2.33.2=py313hc6f7160_0
@@ -53,5 +81,12 @@ dependencies:
   - typing_extensions=4.12.2=py313h06a4308_0
   - tzdata=2025a=h04d1e81_0
   - wheel=0.45.1=py313h06a4308_0
+  - xorg-libx11=1.8.12=h9b100fa_1
+  - xorg-libxau=1.0.12=h9b100fa_0
+  - xorg-libxdmcp=1.1.5=h9b100fa_0
+  - xorg-libxext=1.3.6=h9b100fa_0
+  - xorg-libxrender=0.9.12=h9b100fa_0
+  - xorg-xorgproto=2024.1=h5eee18b_1
   - xz=5.6.4=h5eee18b_1
   - zlib=1.2.13=h5eee18b_1
+  - zstd=1.5.6=hc292b87_0

--- a/environment.yml
+++ b/environment.yml
@@ -5,12 +5,21 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=main
   - _openmp_mutex=5.1=1_gnu
+  - annotated-types=0.6.0=py313h06a4308_1
+  - anyio=4.12.1=py313h06a4308_0
   - bzip2=1.0.8=h5eee18b_6
-  - ca-certificates=2025.2.25=h06a4308_0
+  - ca-certificates=2026.5.14=h06a4308_0
+  - certifi=2026.5.20=py313h06a4308_0
   - colorlog=6.9.0=pyh707e725_1
+  - distro=1.9.0=py313h06a4308_0
   - expat=2.6.4=h6a678d5_0
   - greenlet=3.1.1=py313h6a678d5_0
+  - h11=0.16.0=py313h06a4308_1
+  - httpcore=1.0.9=py313h06a4308_0
+  - httpx=0.28.1=py313h06a4308_1
+  - idna=3.18=py313h06a4308_0
   - iniconfig=1.1.1=pyhd3eb1b0_0
+  - jiter=0.12.0=py313h498d7c9_0
   - ld_impl_linux-64=2.40=h12ee557_0
   - libffi=3.4.4=h6a678d5_1
   - libgcc=14.2.0=h767d61c_2
@@ -20,21 +29,27 @@ dependencies:
   - libstdcxx-ng=11.2.0=h1234567_1
   - libuuid=1.41.5=h5eee18b_0
   - ncurses=6.4=h6a678d5_0
-  - openssl=3.4.1=h7b32b05_0
+  - openai=2.30.0=py313h06a4308_0
+  - openssl=3.5.6=h1b28b03_0
   - packaging=24.2=py313h06a4308_0
   - phonenumbers=8.13.49=py313h06a4308_0
   - pip=25.0=py313h06a4308_0
   - pluggy=1.5.0=py313h06a4308_0
   - pycountry=24.6.1=pyhd8ed1ab_0
+  - pydantic=2.11.9=py313h06a4308_0
+  - pydantic-core=2.33.2=py313hc6f7160_0
   - pytest=8.3.4=py313h06a4308_0
   - python=3.13.2=hf623796_100_cp313
   - python_abi=3.13=0_cp313
   - readline=8.2=h5eee18b_0
   - setuptools=75.8.0=py313h06a4308_0
+  - sniffio=1.3.1=py313h06a4308_0
   - sqlalchemy=2.0.37=py313h00e1ef3_0
   - sqlite=3.45.3=h5eee18b_0
   - tk=8.6.14=h39e8969_0
+  - tqdm=4.67.3=py313h7040dfc_1
   - typing-extensions=4.12.2=py313h06a4308_0
+  - typing-inspection=0.4.2=py313h06a4308_0
   - typing_extensions=4.12.2=py313h06a4308_0
   - tzdata=2025a=h04d1e81_0
   - wheel=0.45.1=py313h06a4308_0

--- a/test/llm/__init__.py
+++ b/test/llm/__init__.py
@@ -1,0 +1,12 @@
+#! python3
+# -*- coding: utf-8 -*-
+"""
+@File   : __init__.py
+@Created: 2026/06/04
+@Author : Gemini CLI
+@Description: Test utilities and constants for LLM module.
+"""
+
+# Legacy test constants from temp_openai_service.py
+DEFAULT_API_KEY = "5511667"
+DEFAULT_TIMEOUT_LIMIT = 60

--- a/test/llm/live/.env.example
+++ b/test/llm/live/.env.example
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Live LLM API credentials for manual smoke testing.
+#
+# Copy this file to `.env` in the same directory and fill in real values:
+#   cp test/llm/live/.env.example test/llm/live/.env
+# The real `.env` is already git-ignored (see .gitignore "Environments"),
+# so your keys never get committed. This `.env.example` is a tracked template.
+#
+# Omit a provider's block to skip it during the run.
+
+# --- OpenAIChat (OpenAI Chat Completion compatible) ---
+OPENAI_CHAT_BASE_URL="https://api.openai.com"
+OPENAI_CHAT_API_KEY="sk-XXXXXX"
+OPENAI_CHAT_MODEL="gpt-5.5-turbo"
+
+# --- AnthropicMessages (Anthropic Messages compatible) ---
+ANTHROPIC_MESSAGES_BASE_URL="https://api.anthropic.com"
+ANTHROPIC_MESSAGES_API_KEY="sk-ant-XXXXXX"
+ANTHROPIC_MESSAGES_MODEL="claude-opus-4-8"

--- a/test/llm/live/__init__.py
+++ b/test/llm/live/__init__.py
@@ -1,0 +1,11 @@
+#! python3
+# -*- encoding: utf-8 -*-
+"""Manual live API smoke tests for the LLM providers (not run by pytest).
+
+@File   :   __init__.py
+@Created:   2026/06/07 01:00
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+# Here put the import lib.

--- a/test/llm/live/run_live.py
+++ b/test/llm/live/run_live.py
@@ -39,24 +39,17 @@ from ark.llm.tools import FunctionTool
 
 ENV_PATH = path.join(path.dirname(__file__), ".env")
 
-def _get_weather(city: str) -> tuple:
-    """Stub weather tool returning a deterministic result."""
+def __get_weather(city: str) -> tuple:
+    """Get the current weather for a city.
+
+    Args:
+        city (str): City name
+    """
     return True, f"It is 22C and sunny in {city}."
 
 
 # A trivial tool used to verify the multi-turn tool-calling loop end to end.
-WEATHER_TOOL = FunctionTool(
-    name="get_weather",
-    description="Get the current weather for a city.",
-    parameters_schema={
-        "type": "object",
-        "properties": {
-            "city": {"type": "string", "description": "City name"},
-        },
-        "required": ["city"],
-    },
-    mapped_callable=_get_weather
-)
+WEATHER_TOOL = FunctionTool(mapped_callable=__get_weather, name="get_weather")
 
 
 def _load_env() -> Dict[str, str]:

--- a/test/llm/live/run_live.py
+++ b/test/llm/live/run_live.py
@@ -35,29 +35,28 @@ from os import path
 from typing import Any, Dict, Optional
 
 from ark.llm import AnthropicMessages, OpenAIChat, BaseLLMClient
+from ark.llm.tools import FunctionTool
 
 ENV_PATH = path.join(path.dirname(__file__), ".env")
-
-# A trivial tool used to verify the multi-turn tool-calling loop end to end.
-WEATHER_TOOL = {
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get the current weather for a city.",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "city": {"type": "string", "description": "City name"},
-            },
-            "required": ["city"],
-        },
-    },
-}
-
 
 def _get_weather(city: str) -> tuple:
     """Stub weather tool returning a deterministic result."""
     return True, f"It is 22C and sunny in {city}."
+
+
+# A trivial tool used to verify the multi-turn tool-calling loop end to end.
+WEATHER_TOOL = FunctionTool(
+    name="get_weather",
+    description="Get the current weather for a city.",
+    parameters_schema={
+        "type": "object",
+        "properties": {
+            "city": {"type": "string", "description": "City name"},
+        },
+        "required": ["city"],
+    },
+    mapped_callable=_get_weather
+)
 
 
 def _load_env() -> Dict[str, str]:
@@ -141,7 +140,6 @@ def run_openai(kwargs: Dict[str, Any]) -> None:
     """Runs the scenario battery against the OpenAI-compatible provider."""
     client = OpenAIChat(
         tools=[WEATHER_TOOL],
-        tool_function_mapper={"get_weather": _get_weather},
         **kwargs)
     _run_scenarios("OpenAIChat", client)
 
@@ -150,7 +148,6 @@ def run_anthropic(kwargs: Dict[str, Any]) -> None:
     """Runs the scenario battery against the Anthropic-compatible provider."""
     client = AnthropicMessages(
         tools=[WEATHER_TOOL],
-        tool_function_mapper={"get_weather": _get_weather},
         **kwargs)
     _run_scenarios("AnthropicMessages", client)
 

--- a/test/llm/live/run_live.py
+++ b/test/llm/live/run_live.py
@@ -1,0 +1,191 @@
+#! python3
+# -*- encoding: utf-8 -*-
+"""
+@File   :   run_live.py
+@Created:   2026/06/07 01:00
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+# Here put the import lib.
+"""Manual live smoke test for the LLM providers against real APIs.
+
+This script is intentionally **not** collected by pytest (filename does not
+start with ``test_``) and never runs in CI. It reads credentials from a
+git-ignored ``.env`` sitting next to this file and exercises both
+``OpenAIChat`` and ``AnthropicMessages`` end to end.
+
+Usage:
+    1. Copy the template and fill in real values (the real .env is git-ignored):
+         cp test/llm/live/.env.example test/llm/live/.env
+       Then edit test/llm/live/.env.
+    2. Run from the repo root (so the ``ark`` package is importable):
+         python -m test.llm.live.run_live          # both providers, all scenarios
+         python -m test.llm.live.run_live openai    # only the openai section
+         python -m test.llm.live.run_live anthropic # only the anthropic section
+
+Each provider section runs: non-streaming ask, streaming ask, and a one-tool
+round trip. Leave a provider's API_KEY blank/absent in .env to skip it.
+
+Expected .env variables (see .env.example):
+    OPENAI_CHAT_BASE_URL / OPENAI_CHAT_API_KEY / OPENAI_CHAT_MODEL
+    ANTHROPIC_MESSAGES_BASE_URL / ANTHROPIC_MESSAGES_API_KEY / ANTHROPIC_MESSAGES_MODEL
+
+@File   :   run_live.py
+@Created:   2026/06/06 00:00
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+import sys
+from os import path
+from typing import Any, Dict, Optional
+
+from ark.llm import AnthropicMessages, OpenAIChat, BaseLLMClient
+
+ENV_PATH = path.join(path.dirname(__file__), ".env")
+
+# A trivial tool used to verify the multi-turn tool-calling loop end to end.
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "City name"},
+            },
+            "required": ["city"],
+        },
+    },
+}
+
+
+def _get_weather(city: str) -> tuple:
+    """Stub weather tool returning a deterministic result."""
+    return True, f"It is 22C and sunny in {city}."
+
+
+def _load_env() -> Dict[str, str]:
+    """Parses the git-ignored .env file into a dict, or exits with guidance.
+
+    Supports ``KEY=value`` lines with optional ``export`` prefix, ``#``
+    comments, blank lines, and surrounding single/double quotes on values.
+
+    Returns:
+        A mapping of environment variable names to their string values.
+    """
+    if not path.exists(ENV_PATH):
+        sys.exit(
+            f"Missing {ENV_PATH}.\n"
+            "Copy the template and fill in real values:\n"
+            "  cp test/llm/live/.env.example test/llm/live/.env")
+
+    env: Dict[str, str] = {}
+    with open(ENV_PATH, "r", encoding="utf-8") as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):]
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if key:
+                env[key] = value
+    return env
+
+
+def _client_kwargs(env: Dict[str, str], prefix: str) -> Optional[Dict[str, Any]]:
+    """Builds client kwargs from ``{prefix}_BASE_URL/API_KEY/MODEL`` vars.
+
+    Args:
+        env: The parsed .env mapping.
+        prefix: The variable-name prefix (e.g. ``"OPENAI_CHAT"``).
+
+    Returns:
+        A kwargs dict for the client constructor, or None if no API key is set
+        (signalling the section should be skipped).
+    """
+    api_key = env.get(f"{prefix}_API_KEY", "").strip()
+    if not api_key or api_key.endswith("XXXXXX"):
+        return None
+
+    kwargs: Dict[str, Any] = {"api_key": api_key}
+    base_url = env.get(f"{prefix}_BASE_URL", "").strip()
+    if base_url:
+        kwargs["base_url"] = base_url
+    model = env.get(f"{prefix}_MODEL", "").strip()
+    if model:
+        kwargs["default_model"] = model
+    return kwargs
+
+
+def _run_scenarios(label: str, client: Any) -> None:
+    """Runs the shared scenario battery against an initialized client."""
+    print(f"\n{'=' * 60}\n[{label}] non-streaming ask\n{'=' * 60}")
+    resp = client.ask("Reply with exactly: pong", stream=False)
+    print(f"success={resp.success} status={resp.status_code}")
+    print(f"content={resp.content!r}")
+    print(f"usage={resp.usage}")
+
+    print(f"\n{'=' * 60}\n[{label}] streaming ask\n{'=' * 60}")
+    for chunk in client.ask("Count from 1 to 5, space separated.", stream=True):
+        if chunk.content:
+            print(chunk.content, end="", flush=True)
+    print()
+
+    print(f"\n{'=' * 60}\n[{label}] tool-calling round\n{'=' * 60}")
+    tool_resp = client.ask("What's the weather in Paris? Use the tool.",
+                           stream=False)
+    print(f"content={tool_resp.content!r}")
+    print(f"latest_tool_call_result={client.latest_tool_call_result}")
+
+
+def run_openai(kwargs: Dict[str, Any]) -> None:
+    """Runs the scenario battery against the OpenAI-compatible provider."""
+    client = OpenAIChat(
+        tools=[WEATHER_TOOL],
+        tool_function_mapper={"get_weather": _get_weather},
+        **kwargs)
+    _run_scenarios("OpenAIChat", client)
+
+
+def run_anthropic(kwargs: Dict[str, Any]) -> None:
+    """Runs the scenario battery against the Anthropic-compatible provider."""
+    client = AnthropicMessages(
+        tools=[WEATHER_TOOL],
+        tool_function_mapper={"get_weather": _get_weather},
+        **kwargs)
+    _run_scenarios("AnthropicMessages", client)
+
+
+def main(only: Optional[str] = None) -> None:
+    """Entry point: runs the requested provider section(s).
+
+    Args:
+        only: ``"openai"`` or ``"anthropic"`` to run a single section, or None
+            for every provider whose API key is present in the .env file.
+    """
+    env = _load_env()
+    runners = {
+        "openai": ("OPENAI_CHAT", run_openai),
+        "anthropic": ("ANTHROPIC_MESSAGES", run_anthropic),
+    }
+
+    selected = [only] if only else list(runners)
+    for name in selected:
+        if name not in runners:
+            sys.exit(f"Unknown provider '{name}'. Choose from: {list(runners)}")
+        prefix, runner = runners[name]
+        kwargs = _client_kwargs(env, prefix)
+        if kwargs is None:
+            print(f"\n[skip] no usable {prefix}_API_KEY in .env for '{name}'")
+            continue
+        runner(kwargs)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else None)

--- a/test/llm/live/run_live.py
+++ b/test/llm/live/run_live.py
@@ -1,13 +1,5 @@
 #! python3
 # -*- encoding: utf-8 -*-
-"""
-@File   :   run_live.py
-@Created:   2026/06/07 01:00
-@Author :   SwordJack
-@Contact:   https://github.com/SwordJack/
-"""
-
-# Here put the import lib.
 """Manual live smoke test for the LLM providers against real APIs.
 
 This script is intentionally **not** collected by pytest (filename does not
@@ -32,11 +24,12 @@ Expected .env variables (see .env.example):
     ANTHROPIC_MESSAGES_BASE_URL / ANTHROPIC_MESSAGES_API_KEY / ANTHROPIC_MESSAGES_MODEL
 
 @File   :   run_live.py
-@Created:   2026/06/06 00:00
+@Created:   2026/06/07 01:00
 @Author :   SwordJack
 @Contact:   https://github.com/SwordJack/
 """
 
+# Here put the import lib.
 import sys
 from os import path
 from typing import Any, Dict, Optional

--- a/test/llm/providers/__init__.py
+++ b/test/llm/providers/__init__.py
@@ -1,0 +1,2 @@
+#! python3
+# -*- coding: utf-8 -*-

--- a/test/llm/providers/test_anthropic_messages.py
+++ b/test/llm/providers/test_anthropic_messages.py
@@ -177,8 +177,10 @@ def test_toolset_get_anthropic_schema():
     assert "input_schema" in schemas[0]
 
 
+from ark.llm.entities import ToolCall
+
 def test_execute_tool_calls_anthropic_blocks():
-    """Anthropic tool execution returns tool_result blocks."""
+    """Tool execution returns raw outputs now."""
     def tool_a(x):
         return True, f"got {x}"
 
@@ -187,15 +189,13 @@ def test_execute_tool_calls_anthropic_blocks():
         "function": {"name": "tool_a", "parameters": {"type": "object", "properties": {"x": {"type": "integer"}}}},
     }
     ts = ToolSet([FunctionTool.from_openai_schema(openai_def, {"tool_a": tool_a})])
-    calls = [{"id": "tu1", "type": "function",
-              "function": {"name": "tool_a", "arguments": '{"x": 5}'}}]
-    blocks, results = ts.execute_tool_calls_anthropic(calls)
+    calls = [ToolCall(id="tu1", name="tool_a", arguments='{"x": 5}')]
+
+    # ToolSet now only returns raw tool outputs. The anthropic method does not exist.
+    outputs, results = ts.execute_tool_calls(calls)
 
     assert results["tool_a"] is True
-    assert blocks[0]["type"] == "tool_result"
-    assert blocks[0]["tool_use_id"] == "tu1"
-    assert blocks[0]["content"] == "got 5"
-    assert "is_error" not in blocks[0]
+    assert outputs[0] == "got 5"
 
 
 # --- Client behavior --------------------------------------------------------

--- a/test/llm/providers/test_anthropic_messages.py
+++ b/test/llm/providers/test_anthropic_messages.py
@@ -11,6 +11,15 @@
 from unittest.mock import MagicMock, patch
 import pytest
 from PIL import Image
+from anthropic.types import (
+    Message,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawMessageStopEvent,
+)
 from ark.llm.providers.anthropic_messages import AnthropicMessages
 from ark.llm import LLMResponse
 from ark.llm.tools import FunctionTool, ToolSet
@@ -61,24 +70,55 @@ def _message(content, input_tokens=0, output_tokens=0):
     return m
 
 
-def _delta_event(delta_type, **fields):
-    """Builds a mock content_block_delta stream event."""
-    e = MagicMock()
-    e.type = "content_block_delta"
-    e.delta = MagicMock(type=delta_type, **fields)
-    return e
+def _start_event(content=None, input_tokens=10):
+    """Builds a real message_start event.
+
+    ``content`` defaults to None to mirror the Anthropic-*compatible* gateways
+    that send ``message.content: null`` — the framing that crashed the SDK's
+    stream accumulator. We feed real event models (not mocks) so the test
+    exercises the actual normalization + ``accumulate_event`` path.
+    """
+    message = Message.construct(
+        id="m1", type="message", role="assistant", model="x",
+        content=content, stop_reason=None, stop_sequence=None,
+        usage={"input_tokens": input_tokens, "output_tokens": 0})
+    return RawMessageStartEvent.construct(type="message_start", message=message)
 
 
-def _set_stream(mock_instance, events, final_message):
-    """Wires client.messages.stream() to a context manager mock."""
-    stream_obj = MagicMock()
-    stream_obj.__iter__.return_value = iter(events)
-    stream_obj.get_final_message.return_value = final_message
+def _block_start_event(index, content_block):
+    """Builds a real content_block_start event for the given block dict."""
+    return RawContentBlockStartEvent.construct(
+        type="content_block_start", index=index, content_block=content_block)
 
-    cm = MagicMock()
-    cm.__enter__.return_value = stream_obj
-    cm.__exit__.return_value = False
-    mock_instance.messages.stream.return_value = cm
+
+def _delta_event(index, delta):
+    """Builds a real content_block_delta event from a delta dict."""
+    return RawContentBlockDeltaEvent.construct(
+        type="content_block_delta", index=index, delta=delta)
+
+
+def _block_stop_event(index):
+    """Builds a real content_block_stop event."""
+    return RawContentBlockStopEvent.construct(
+        type="content_block_stop", index=index)
+
+
+def _message_delta_event(output_tokens):
+    """Builds a real message_delta event carrying final output token usage."""
+    return RawMessageDeltaEvent.construct(
+        type="message_delta",
+        delta={"stop_reason": "end_turn", "stop_sequence": None},
+        usage={"output_tokens": output_tokens})
+
+
+def _stop_event():
+    """Builds a real message_stop event."""
+    return RawMessageStopEvent.construct(type="message_stop")
+
+
+def _set_stream(mock_instance, events):
+    """Wires client.messages.create(stream=True) to yield raw events."""
+    mock_instance.messages.create.return_value = iter(events)
 
 
 # --- Schema conversion (provider-neutral tool format) -----------------------
@@ -215,14 +255,23 @@ def test_ask_thinking_into_reasoning(mock_anthropic):
 
 
 def test_ask_stream_success(mock_anthropic):
-    """Streaming ask yields incremental text then a final usage summary."""
+    """Streaming ask yields incremental text from raw events.
+
+    The message_start event carries ``content=None`` on purpose: this is the
+    compatible-gateway framing that crashed the SDK's high-level accumulator,
+    so the test pins that we now consume raw events and survive it.
+    """
     mock_instance = mock_anthropic.return_value
     events = [
-        _delta_event("text_delta", text="Hel"),
-        _delta_event("text_delta", text="lo"),
+        _start_event(content=None),
+        _block_start_event(0, {"type": "text", "text": ""}),
+        _delta_event(0, {"type": "text_delta", "text": "Hel"}),
+        _delta_event(0, {"type": "text_delta", "text": "lo"}),
+        _block_stop_event(0),
+        _message_delta_event(output_tokens=5),
+        _stop_event(),
     ]
-    final = _message([_text_block("Hello")], input_tokens=10, output_tokens=5)
-    _set_stream(mock_instance, events, final)
+    _set_stream(mock_instance, events)
 
     client = AnthropicMessages(api_key="test-key")
     chunks = list(client.ask("Hi", stream=True))
@@ -230,6 +279,53 @@ def test_ask_stream_success(mock_anthropic):
     text_chunks = [c for c in chunks if c.content]
     assert "".join(c.content for c in text_chunks) == "Hello"
     assert len(client.messages) == 2
+
+
+def test_ask_stream_tool_call(mock_anthropic):
+    """Streaming tool_use is reconstructed from raw events and executed.
+
+    Verifies tool_use input is rebuilt from input_json_delta fragments (the
+    raw-event path) and that the tool round runs to a final streamed answer.
+    """
+    def tool_a(x):
+        return True, f"Done {x}"
+
+    tool_def = {
+        "type": "function",
+        "function": {"name": "tool_a", "parameters": {"type": "object", "properties": {"x": {"type": "integer"}}}},
+    }
+    client = AnthropicMessages(api_key="test-key", tools=[tool_def],
+                               tool_function_mapper={"tool_a": tool_a})
+    mock_instance = mock_anthropic.return_value
+
+    # Round 1: a tool_use block whose input streams in as partial JSON; the SDK
+    # accumulator reassembles it (we don't hand-parse partial_json ourselves).
+    round1 = [
+        _start_event(content=None),
+        _block_start_event(0, {"type": "tool_use", "id": "tu1",
+                               "name": "tool_a", "input": {}}),
+        _delta_event(0, {"type": "input_json_delta", "partial_json": '{"x":'}),
+        _delta_event(0, {"type": "input_json_delta", "partial_json": ' 1}'}),
+        _block_stop_event(0),
+        _message_delta_event(output_tokens=2),
+        _stop_event(),
+    ]
+    # Round 2: final text answer.
+    round2 = [
+        _start_event(content=None),
+        _block_start_event(0, {"type": "text", "text": ""}),
+        _delta_event(0, {"type": "text_delta", "text": "Done"}),
+        _block_stop_event(0),
+        _message_delta_event(output_tokens=2),
+        _stop_event(),
+    ]
+    mock_instance.messages.create.side_effect = [iter(round1), iter(round2)]
+
+    chunks = list(client.ask("Run tool", stream=True))
+
+    assert "".join(c.content for c in chunks if c.content) == "Done"
+    assert client.latest_tool_call_result["tool_a"] is True
+    assert mock_instance.messages.create.call_count == 2
 
 
 def test_multi_turn_tool(mock_anthropic):

--- a/test/llm/providers/test_anthropic_messages.py
+++ b/test/llm/providers/test_anthropic_messages.py
@@ -208,13 +208,13 @@ def test_init_system_not_in_messages(mock_anthropic):
 
 
 def test_atomic_completion(mock_anthropic):
-    """The atomic chat_completion method parses text and does not touch history."""
+    """The atomic generate method parses text and does not touch history."""
     mock_instance = mock_anthropic.return_value
     mock_instance.messages.create.return_value = _message(
         [_text_block("Atomic Response")], input_tokens=3, output_tokens=2)
 
     client = AnthropicMessages(api_key="test-key")
-    response = client.chat_completion(messages=[{"role": "user", "content": "Hi"}])
+    response = client.generate(messages=[{"role": "user", "content": "Hi"}])
 
     assert response.success is True
     assert response.content == "Atomic Response"

--- a/test/llm/providers/test_anthropic_messages.py
+++ b/test/llm/providers/test_anthropic_messages.py
@@ -290,12 +290,12 @@ def test_ask_stream_tool_call(mock_anthropic):
     def tool_a(x):
         return True, f"Done {x}"
 
-    tool_def = {
-        "type": "function",
-        "function": {"name": "tool_a", "parameters": {"type": "object", "properties": {"x": {"type": "integer"}}}},
-    }
-    client = AnthropicMessages(api_key="test-key", tools=[tool_def],
-                               tool_function_mapper={"tool_a": tool_a})
+    tool_def = FunctionTool(
+        name="tool_a",
+        parameters_schema={"type": "object", "properties": {"x": {"type": "integer"}}},
+        mapped_callable=tool_a
+    )
+    client = AnthropicMessages(api_key="test-key", tools=[tool_def])
     mock_instance = mock_anthropic.return_value
 
     # Round 1: a tool_use block whose input streams in as partial JSON; the SDK
@@ -333,12 +333,12 @@ def test_multi_turn_tool(mock_anthropic):
     def tool_a(x):
         return True, f"Done {x}"
 
-    tool_def = {
-        "type": "function",
-        "function": {"name": "tool_a", "parameters": {"type": "object", "properties": {"x": {"type": "integer"}}}},
-    }
-    client = AnthropicMessages(api_key="test-key", tools=[tool_def],
-                               tool_function_mapper={"tool_a": tool_a})
+    tool_def = FunctionTool(
+        name="tool_a",
+        parameters_schema={"type": "object", "properties": {"x": {"type": "integer"}}},
+        mapped_callable=tool_a
+    )
+    client = AnthropicMessages(api_key="test-key", tools=[tool_def])
     mock_instance = mock_anthropic.return_value
 
     # Round 1: model calls the tool. Round 2: final answer.

--- a/test/llm/providers/test_anthropic_messages.py
+++ b/test/llm/providers/test_anthropic_messages.py
@@ -120,78 +120,22 @@ def _set_stream(mock_instance, events):
     """Wires client.messages.create(stream=True) to yield raw events."""
     mock_instance.messages.create.return_value = iter(events)
 
-
-# --- Schema conversion (provider-neutral tool format) -----------------------
-
-def test_function_tool_to_anthropic_schema():
-    """OpenAI-shaped tools render to Anthropic's flat schema."""
-    openai_def = {
-        "type": "function",
-        "function": {
-            "name": "tool_a",
-            "description": "does a",
-            "parameters": {
-                "type": "object",
-                "properties": {"x": {"type": "integer"}},
-                "required": ["x"],
-            },
-        },
-    }
-    tool = FunctionTool.from_openai_schema(openai_def)
-    schema = tool.to_anthropic_schema()
-    assert schema["name"] == "tool_a"
-    assert schema["description"] == "does a"
-    assert schema["input_schema"]["type"] == "object"
-    assert schema["input_schema"]["properties"]["x"]["type"] == "integer"
-    assert schema["input_schema"]["required"] == ["x"]
-
-
-def test_anthropic_to_openai_roundtrip():
-    """Anthropic schema ingests and renders back to OpenAI shape."""
-    anthropic_def = {
-        "name": "tool_b",
-        "description": "does b",
-        "input_schema": {
-            "type": "object",
-            "properties": {"y": {"type": "string"}},
-            "required": ["y"],
-        },
-    }
-    tool = FunctionTool.from_anthropic_schema(anthropic_def)
-    openai_schema = tool.to_openai_schema()
-    assert openai_schema["type"] == "function"
-    assert openai_schema["function"]["name"] == "tool_b"
-    assert openai_schema["function"]["parameters"]["properties"]["y"]["type"] == "string"
-
-
-def test_toolset_get_anthropic_schema():
-    """ToolSet exposes the Anthropic schema list."""
-    openai_def = {
-        "type": "function",
-        "function": {"name": "t", "parameters": {"type": "object", "properties": {}}},
-    }
-    ts = ToolSet([FunctionTool.from_openai_schema(openai_def)])
-    schemas = ts.get_anthropic_schema()
-    assert len(schemas) == 1
-    assert schemas[0]["name"] == "t"
-    assert "input_schema" in schemas[0]
-
-
 from ark.llm.entities import ToolCall
 
-def test_execute_tool_calls_anthropic_blocks():
+def test_execute_tool_calls_raw_outputs():
     """Tool execution returns raw outputs now."""
     def tool_a(x):
         return True, f"got {x}"
 
-    openai_def = {
-        "type": "function",
-        "function": {"name": "tool_a", "parameters": {"type": "object", "properties": {"x": {"type": "integer"}}}},
-    }
-    ts = ToolSet([FunctionTool.from_openai_schema(openai_def, {"tool_a": tool_a})])
+    tool_def = FunctionTool(
+        name="tool_a",
+        parameters_schema={"type": "object", "properties": {"x": {"type": "integer"}}},
+        mapped_callable=tool_a
+    )
+    ts = ToolSet([tool_def])
     calls = [ToolCall(id="tu1", name="tool_a", arguments='{"x": 5}')]
 
-    # ToolSet now only returns raw tool outputs. The anthropic method does not exist.
+    # ToolSet now only returns raw tool outputs.
     outputs, results = ts.execute_tool_calls(calls)
 
     assert results["tool_a"] is True

--- a/test/llm/providers/test_anthropic_messages.py
+++ b/test/llm/providers/test_anthropic_messages.py
@@ -1,0 +1,284 @@
+#! python3
+# -*- encoding: utf-8 -*-
+"""
+@File   :   test_anthropic_messages.py
+@Created:   2026/06/06 21:15
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+# Here put the import lib.
+from unittest.mock import MagicMock, patch
+import pytest
+from PIL import Image
+from ark.llm.providers.anthropic_messages import AnthropicMessages
+from ark.llm import LLMResponse
+from ark.llm.tools import FunctionTool, ToolSet
+
+
+@pytest.fixture
+def mock_anthropic():
+    """Fixture to mock the Anthropic client."""
+    with patch("ark.llm.providers.anthropic_messages.Anthropic") as mock:
+        yield mock
+
+
+def _text_block(text):
+    """Builds a mock Anthropic text content block."""
+    b = MagicMock()
+    b.type = "text"
+    b.text = text
+    return b
+
+
+def _thinking_block(thinking):
+    """Builds a mock Anthropic thinking content block."""
+    b = MagicMock()
+    b.type = "thinking"
+    b.thinking = thinking
+    return b
+
+
+def _tool_use_block(block_id, name, tool_input):
+    """Builds a mock Anthropic tool_use content block."""
+    b = MagicMock()
+    b.type = "tool_use"
+    b.id = block_id
+    b.name = name
+    b.input = tool_input
+    return b
+
+
+def _message(content, input_tokens=0, output_tokens=0):
+    """Builds a mock Anthropic Message response."""
+    m = MagicMock()
+    m.content = content
+    if input_tokens or output_tokens:
+        m.usage = MagicMock(input_tokens=input_tokens,
+                            output_tokens=output_tokens)
+    else:
+        m.usage = None
+    return m
+
+
+def _delta_event(delta_type, **fields):
+    """Builds a mock content_block_delta stream event."""
+    e = MagicMock()
+    e.type = "content_block_delta"
+    e.delta = MagicMock(type=delta_type, **fields)
+    return e
+
+
+def _set_stream(mock_instance, events, final_message):
+    """Wires client.messages.stream() to a context manager mock."""
+    stream_obj = MagicMock()
+    stream_obj.__iter__.return_value = iter(events)
+    stream_obj.get_final_message.return_value = final_message
+
+    cm = MagicMock()
+    cm.__enter__.return_value = stream_obj
+    cm.__exit__.return_value = False
+    mock_instance.messages.stream.return_value = cm
+
+
+# --- Schema conversion (provider-neutral tool format) -----------------------
+
+def test_function_tool_to_anthropic_schema():
+    """OpenAI-shaped tools render to Anthropic's flat schema."""
+    openai_def = {
+        "type": "function",
+        "function": {
+            "name": "tool_a",
+            "description": "does a",
+            "parameters": {
+                "type": "object",
+                "properties": {"x": {"type": "integer"}},
+                "required": ["x"],
+            },
+        },
+    }
+    tool = FunctionTool.from_openai_schema(openai_def)
+    schema = tool.to_anthropic_schema()
+    assert schema["name"] == "tool_a"
+    assert schema["description"] == "does a"
+    assert schema["input_schema"]["type"] == "object"
+    assert schema["input_schema"]["properties"]["x"]["type"] == "integer"
+    assert schema["input_schema"]["required"] == ["x"]
+
+
+def test_anthropic_to_openai_roundtrip():
+    """Anthropic schema ingests and renders back to OpenAI shape."""
+    anthropic_def = {
+        "name": "tool_b",
+        "description": "does b",
+        "input_schema": {
+            "type": "object",
+            "properties": {"y": {"type": "string"}},
+            "required": ["y"],
+        },
+    }
+    tool = FunctionTool.from_anthropic_schema(anthropic_def)
+    openai_schema = tool.to_openai_schema()
+    assert openai_schema["type"] == "function"
+    assert openai_schema["function"]["name"] == "tool_b"
+    assert openai_schema["function"]["parameters"]["properties"]["y"]["type"] == "string"
+
+
+def test_toolset_get_anthropic_schema():
+    """ToolSet exposes the Anthropic schema list."""
+    openai_def = {
+        "type": "function",
+        "function": {"name": "t", "parameters": {"type": "object", "properties": {}}},
+    }
+    ts = ToolSet([FunctionTool.from_openai_schema(openai_def)])
+    schemas = ts.get_anthropic_schema()
+    assert len(schemas) == 1
+    assert schemas[0]["name"] == "t"
+    assert "input_schema" in schemas[0]
+
+
+def test_execute_tool_calls_anthropic_blocks():
+    """Anthropic tool execution returns tool_result blocks."""
+    def tool_a(x):
+        return True, f"got {x}"
+
+    openai_def = {
+        "type": "function",
+        "function": {"name": "tool_a", "parameters": {"type": "object", "properties": {"x": {"type": "integer"}}}},
+    }
+    ts = ToolSet([FunctionTool.from_openai_schema(openai_def, {"tool_a": tool_a})])
+    calls = [{"id": "tu1", "type": "function",
+              "function": {"name": "tool_a", "arguments": '{"x": 5}'}}]
+    blocks, results = ts.execute_tool_calls_anthropic(calls)
+
+    assert results["tool_a"] is True
+    assert blocks[0]["type"] == "tool_result"
+    assert blocks[0]["tool_use_id"] == "tu1"
+    assert blocks[0]["content"] == "got 5"
+    assert "is_error" not in blocks[0]
+
+
+# --- Client behavior --------------------------------------------------------
+
+def test_init_system_not_in_messages(mock_anthropic):
+    """System instructions stay top-level, never in the message list."""
+    client = AnthropicMessages(api_key="test-key", instructions="System rules")
+    assert client.instructions == "System rules"
+    assert len(client.messages) == 0
+
+
+def test_atomic_completion(mock_anthropic):
+    """The atomic chat_completion method parses text and does not touch history."""
+    mock_instance = mock_anthropic.return_value
+    mock_instance.messages.create.return_value = _message(
+        [_text_block("Atomic Response")], input_tokens=3, output_tokens=2)
+
+    client = AnthropicMessages(api_key="test-key")
+    response = client.chat_completion(messages=[{"role": "user", "content": "Hi"}])
+
+    assert response.success is True
+    assert response.content == "Atomic Response"
+    assert response.usage.total_tokens == 5
+    assert len(client.messages) == 0
+
+
+def test_ask_success(mock_anthropic):
+    """High-level ask with a simple text response."""
+    mock_instance = mock_anthropic.return_value
+    mock_instance.messages.create.return_value = _message(
+        [_text_block("Hello")], input_tokens=4, output_tokens=1)
+
+    client = AnthropicMessages(api_key="test-key")
+    response = client.ask("Hi", stream=False)
+
+    assert isinstance(response, LLMResponse)
+    assert response.success is True
+    assert response.content == "Hello"
+    assert len(client.messages) == 2
+
+
+def test_ask_thinking_into_reasoning(mock_anthropic):
+    """Thinking blocks surface into reasoning_content."""
+    mock_instance = mock_anthropic.return_value
+    mock_instance.messages.create.return_value = _message(
+        [_thinking_block("step by step"), _text_block("Answer")],
+        input_tokens=5, output_tokens=3)
+
+    client = AnthropicMessages(api_key="test-key", thinking={"type": "adaptive"})
+    response = client.ask("Solve", stream=False)
+
+    assert response.content == "Answer"
+    assert response.reasoning_content == "step by step"
+    # thinking config is forwarded to the API
+    _, call_kwargs = mock_instance.messages.create.call_args
+    assert call_kwargs["thinking"] == {"type": "adaptive"}
+
+
+def test_ask_stream_success(mock_anthropic):
+    """Streaming ask yields incremental text then a final usage summary."""
+    mock_instance = mock_anthropic.return_value
+    events = [
+        _delta_event("text_delta", text="Hel"),
+        _delta_event("text_delta", text="lo"),
+    ]
+    final = _message([_text_block("Hello")], input_tokens=10, output_tokens=5)
+    _set_stream(mock_instance, events, final)
+
+    client = AnthropicMessages(api_key="test-key")
+    chunks = list(client.ask("Hi", stream=True))
+
+    text_chunks = [c for c in chunks if c.content]
+    assert "".join(c.content for c in text_chunks) == "Hello"
+    assert len(client.messages) == 2
+
+
+def test_multi_turn_tool(mock_anthropic):
+    """Recursive tool calling: tool_use round then a final answer."""
+    def tool_a(x):
+        return True, f"Done {x}"
+
+    tool_def = {
+        "type": "function",
+        "function": {"name": "tool_a", "parameters": {"type": "object", "properties": {"x": {"type": "integer"}}}},
+    }
+    client = AnthropicMessages(api_key="test-key", tools=[tool_def],
+                               tool_function_mapper={"tool_a": tool_a})
+    mock_instance = mock_anthropic.return_value
+
+    # Round 1: model calls the tool. Round 2: final answer.
+    m1 = _message([_tool_use_block("tu1", "tool_a", {"x": 1})],
+                  input_tokens=5, output_tokens=2)
+    m2 = _message([_text_block("Finished")], input_tokens=6, output_tokens=2)
+    mock_instance.messages.create.side_effect = [m1, m2]
+
+    response = client.ask("Run tool", stream=False)
+
+    assert response.content == "Finished"
+    assert mock_instance.messages.create.call_count == 2
+    assert client.latest_tool_call_result["tool_a"] is True
+
+
+def test_safe_state_on_error(mock_anthropic):
+    """Conversation history is preserved when the API fails."""
+    mock_instance = mock_anthropic.return_value
+    mock_instance.messages.create.side_effect = Exception("API Down")
+
+    client = AnthropicMessages(api_key="test-key", instructions="System")
+    initial_len = len(client.messages)
+
+    response = client.ask("Fail me", stream=False)
+    assert response.success is False
+    assert len(client.messages) == initial_len
+
+
+def test_build_user_message_content_with_image(mock_anthropic):
+    """Multimodal content uses Anthropic base64 image blocks."""
+    img = Image.new("RGB", (2, 2), color="red")
+    content = AnthropicMessages.build_user_message_content("describe", [img])
+
+    assert isinstance(content, list)
+    assert content[0] == {"type": "text", "text": "describe"}
+    assert content[1]["type"] == "image"
+    assert content[1]["source"]["type"] == "base64"
+    assert content[1]["source"]["media_type"] == "image/png"
+    assert content[1]["source"]["data"]

--- a/test/llm/providers/test_openai_chat.py
+++ b/test/llm/providers/test_openai_chat.py
@@ -13,6 +13,7 @@ import pytest
 from PIL import Image
 from ark.llm.providers.openai_chat import OpenAIChat
 from ark.llm import LLMResponse
+from ark.llm.tools import FunctionTool
 
 @pytest.fixture
 def mock_openai_chat():
@@ -88,12 +89,13 @@ def test_openai_chat_ask_stream_success(mock_openai_chat):
 def test_openai_chat_multi_turn_tool(mock_openai_chat):
     """Tests recursive tool calling in ask loop."""
     def tool_a(x: int): return True, f"Done {x}"
-    tool_def = {
-        "type": "function",
-        "function": {"name": "tool_a", "parameters": {"type": "object", "properties": {"x": {"type": "integer"}}}}
-    }
-    
-    client = OpenAIChat(api_key="test-key", tools=[tool_def], tool_function_mapper={"tool_a": tool_a})
+    tool_def = FunctionTool(
+        name="tool_a",
+        parameters_schema={"type": "object", "properties": {"x": {"type": "integer"}}},
+        mapped_callable=tool_a
+    )
+
+    client = OpenAIChat(api_key="test-key", tools=[tool_def])
     mock_instance = mock_openai_chat.return_value
     
     # Round 1: Model calls tool

--- a/test/llm/providers/test_openai_chat.py
+++ b/test/llm/providers/test_openai_chat.py
@@ -1,96 +1,71 @@
 #! python3
 # -*- coding: utf-8 -*-
-from unittest.mock import MagicMock, patch, ANY
+from unittest.mock import MagicMock, patch
 import pytest
 from PIL import Image
 from ark.llm.providers.openai_chat import OpenAIChat
+from ark.llm import LLMResponse
 
 @pytest.fixture
-def mock_openai_client():
+def mock_openai_chat():
     with patch("ark.llm.providers.openai_chat.OpenAI") as mock:
         yield mock
 
-def test_openai_chat_init(mock_openai_client):
-    client = OpenAIChat(
-        api_key="test-key", 
-        base_url="https://test.api", 
-        default_model="test-model",
-        instructions="You are a helpful assistant"
-    )
-    mock_openai_client.assert_called_once_with(api_key="test-key", base_url="https://test.api")
-    assert client.default_model == "test-model"
+def test_openai_chat_init(mock_openai_chat):
+    client = OpenAIChat(api_key="test-key", instructions="System rules")
     assert len(client.messages) == 1
-    assert client.messages[0]["role"] == "system"
+    assert client.messages[0]["content"] == "System rules"
 
-def test_openai_chat_ask_simple(mock_openai_client):
-    mock_instance = mock_openai_client.return_value
-    # Mock streaming response
+def test_openai_chat_ask_success(mock_openai_chat):
+    mock_instance = mock_openai_chat.return_value
     mock_chunk = MagicMock()
     mock_chunk.choices = [MagicMock(delta=MagicMock(content="Hello", tool_calls=None))]
+    mock_chunk.usage = None
     mock_instance.chat.completions.create.return_value = [mock_chunk]
     
     client = OpenAIChat(api_key="test-key")
-    success, status, content = client.ask("Hi")
+    response = client.ask("Hi")
     
-    assert success is True
-    assert status == 200
-    assert content == "Hello"
-    assert len(client.messages) == 2 # User and Assistant
+    assert isinstance(response, LLMResponse)
+    assert response.success is True
+    assert response.content == "Hello"
+    assert len(client.messages) == 2
 
-def test_openai_chat_multimodal_content():
-    prompt = "What is this?"
-    mock_img = MagicMock(spec=Image.Image)
-    
-    with patch("ark.llm.providers.openai_chat.convert_image_to_data_url", return_value="data:image/png;base64,xxx"):
-        content = OpenAIChat.build_user_message_content(prompt, [mock_img])
-    
-    assert isinstance(content, list)
-    assert content[0]["text"] == prompt
-    assert content[1]["image_url"]["url"] == "data:image/png;base64,xxx"
-
-def test_openai_chat_tool_execution(mock_openai_client):
-    # Mock a tool function
-    def my_tool(x):
-        return True, f"Result is {x}"
-    
+def test_openai_chat_multi_turn_tool(mock_openai_chat):
+    def tool_a(x: int): return True, f"Done {x}"
     tool_def = {
         "type": "function",
-        "function": {
-            "name": "my_tool",
-            "parameters": {
-                "type": "object",
-                "properties": {"x": {"type": "integer"}},
-                "required": ["x"]
-            }
-        }
+        "function": {"name": "tool_a", "parameters": {"type": "object", "properties": {"x": {"type": "integer"}}}}
     }
     
-    client = OpenAIChat(
-        api_key="test-key",
-        tools=[tool_def],
-        tool_function_mapper={"my_tool": my_tool}
-    )
+    client = OpenAIChat(api_key="test-key", tools=[tool_def], tool_function_mapper={"tool_a": tool_a})
+    mock_instance = mock_openai_chat.return_value
     
-    mock_instance = mock_openai_client.return_value
+    # Round 1: Model calls tool
+    tc = MagicMock()
+    tc.index = 0
+    tc.id = "c1"
+    tc.function.name = "tool_a"
+    tc.function.arguments = '{"x": 1}'
+    m1 = MagicMock(choices=[MagicMock(delta=MagicMock(content=None, tool_calls=[tc]))], usage=None)
     
-    # Mock first response with tool call
-    mock_tool_call = MagicMock()
-    mock_tool_call.index = 0
-    mock_tool_call.id = "call_123"
-    mock_tool_call.function.name = "my_tool"
-    mock_tool_call.function.arguments = '{"x": 10}'
+    # Round 2: Model gives final answer
+    m2 = MagicMock(choices=[MagicMock(delta=MagicMock(content="Finished", tool_calls=None))], usage=None)
     
-    mock_chunk_1 = MagicMock()
-    mock_chunk_1.choices = [MagicMock(delta=MagicMock(content=None, tool_calls=[mock_tool_call]))]
+    mock_instance.chat.completions.create.side_effect = [[m1], [m2]]
     
-    # Mock second response (after tool)
-    mock_chunk_2 = MagicMock()
-    mock_chunk_2.choices = [MagicMock(delta=MagicMock(content="The result is 10", tool_calls=None))]
+    response = client.ask("Run tool")
+    assert response.content == "Finished"
+    assert mock_instance.chat.completions.create.call_count == 2
+    assert client.latest_tool_call_result["tool_a"] is True
+
+def test_openai_chat_safe_state_on_error(mock_openai_chat):
+    mock_instance = mock_openai_chat.return_value
+    mock_instance.chat.completions.create.side_effect = Exception("API Down")
     
-    mock_instance.chat.completions.create.side_effect = [[mock_chunk_1], [mock_chunk_2]]
+    client = OpenAIChat(api_key="test-key", instructions="System")
+    initial_len = len(client.messages)
     
-    success, status, content = client.ask("Use tool")
-    
-    assert success is True
-    assert content == "The result is 10"
-    assert client.latest_tool_call_result["my_tool"] is True
+    response = client.ask("Fail me")
+    assert response.success is False
+    assert len(client.messages) == initial_len # Should NOT have user/error messages added

--- a/test/llm/providers/test_openai_chat.py
+++ b/test/llm/providers/test_openai_chat.py
@@ -1,0 +1,96 @@
+#! python3
+# -*- coding: utf-8 -*-
+from unittest.mock import MagicMock, patch, ANY
+import pytest
+from PIL import Image
+from ark.llm.providers.openai_chat import OpenAIChat
+
+@pytest.fixture
+def mock_openai_client():
+    with patch("ark.llm.providers.openai_chat.OpenAI") as mock:
+        yield mock
+
+def test_openai_chat_init(mock_openai_client):
+    client = OpenAIChat(
+        api_key="test-key", 
+        base_url="https://test.api", 
+        default_model="test-model",
+        instructions="You are a helpful assistant"
+    )
+    mock_openai_client.assert_called_once_with(api_key="test-key", base_url="https://test.api")
+    assert client.default_model == "test-model"
+    assert len(client.messages) == 1
+    assert client.messages[0]["role"] == "system"
+
+def test_openai_chat_ask_simple(mock_openai_client):
+    mock_instance = mock_openai_client.return_value
+    # Mock streaming response
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [MagicMock(delta=MagicMock(content="Hello", tool_calls=None))]
+    mock_instance.chat.completions.create.return_value = [mock_chunk]
+    
+    client = OpenAIChat(api_key="test-key")
+    success, status, content = client.ask("Hi")
+    
+    assert success is True
+    assert status == 200
+    assert content == "Hello"
+    assert len(client.messages) == 2 # User and Assistant
+
+def test_openai_chat_multimodal_content():
+    prompt = "What is this?"
+    mock_img = MagicMock(spec=Image.Image)
+    
+    with patch("ark.llm.providers.openai_chat.convert_image_to_data_url", return_value="data:image/png;base64,xxx"):
+        content = OpenAIChat.build_user_message_content(prompt, [mock_img])
+    
+    assert isinstance(content, list)
+    assert content[0]["text"] == prompt
+    assert content[1]["image_url"]["url"] == "data:image/png;base64,xxx"
+
+def test_openai_chat_tool_execution(mock_openai_client):
+    # Mock a tool function
+    def my_tool(x):
+        return True, f"Result is {x}"
+    
+    tool_def = {
+        "type": "function",
+        "function": {
+            "name": "my_tool",
+            "parameters": {
+                "type": "object",
+                "properties": {"x": {"type": "integer"}},
+                "required": ["x"]
+            }
+        }
+    }
+    
+    client = OpenAIChat(
+        api_key="test-key",
+        tools=[tool_def],
+        tool_function_mapper={"my_tool": my_tool}
+    )
+    
+    mock_instance = mock_openai_client.return_value
+    
+    # Mock first response with tool call
+    mock_tool_call = MagicMock()
+    mock_tool_call.index = 0
+    mock_tool_call.id = "call_123"
+    mock_tool_call.function.name = "my_tool"
+    mock_tool_call.function.arguments = '{"x": 10}'
+    
+    mock_chunk_1 = MagicMock()
+    mock_chunk_1.choices = [MagicMock(delta=MagicMock(content=None, tool_calls=[mock_tool_call]))]
+    
+    # Mock second response (after tool)
+    mock_chunk_2 = MagicMock()
+    mock_chunk_2.choices = [MagicMock(delta=MagicMock(content="The result is 10", tool_calls=None))]
+    
+    mock_instance.chat.completions.create.side_effect = [[mock_chunk_1], [mock_chunk_2]]
+    
+    success, status, content = client.ask("Use tool")
+    
+    assert success is True
+    assert content == "The result is 10"
+    assert client.latest_tool_call_result["my_tool"] is True

--- a/test/llm/providers/test_openai_chat.py
+++ b/test/llm/providers/test_openai_chat.py
@@ -27,7 +27,7 @@ def test_openai_chat_init(mock_openai_chat):
     assert client.messages[0]["content"] == "System rules"
 
 def test_openai_chat_atomic_completion(mock_openai_chat):
-    """Tests the atomic chat_completion method."""
+    """Tests the atomic generate method."""
     mock_instance = mock_openai_chat.return_value
     m = MagicMock()
     m.choices = [MagicMock(message=MagicMock(content="Atomic Response", tool_calls=None))]
@@ -35,7 +35,7 @@ def test_openai_chat_atomic_completion(mock_openai_chat):
     mock_instance.chat.completions.create.return_value = m
     
     client = OpenAIChat(api_key="test-key")
-    response = client.chat_completion(messages=[{"role": "user", "content": "Hello"}])
+    response = client.generate(messages=[{"role": "user", "content": "Hello"}])
     
     assert response.success is True
     assert response.content == "Atomic Response"

--- a/test/llm/providers/test_openai_chat.py
+++ b/test/llm/providers/test_openai_chat.py
@@ -8,30 +8,77 @@ from ark.llm import LLMResponse
 
 @pytest.fixture
 def mock_openai_chat():
+    """Fixture to mock the OpenAI client."""
     with patch("ark.llm.providers.openai_chat.OpenAI") as mock:
         yield mock
 
 def test_openai_chat_init(mock_openai_chat):
+    """Tests initialization and system instruction setup."""
     client = OpenAIChat(api_key="test-key", instructions="System rules")
     assert len(client.messages) == 1
     assert client.messages[0]["content"] == "System rules"
 
-def test_openai_chat_ask_success(mock_openai_chat):
+def test_openai_chat_atomic_completion(mock_openai_chat):
+    """Tests the atomic chat_completion method."""
     mock_instance = mock_openai_chat.return_value
-    mock_chunk = MagicMock()
-    mock_chunk.choices = [MagicMock(delta=MagicMock(content="Hello", tool_calls=None))]
-    mock_chunk.usage = None
-    mock_instance.chat.completions.create.return_value = [mock_chunk]
+    m = MagicMock()
+    m.choices = [MagicMock(message=MagicMock(content="Atomic Response", tool_calls=None))]
+    m.usage = None
+    mock_instance.chat.completions.create.return_value = m
     
     client = OpenAIChat(api_key="test-key")
-    response = client.ask("Hi")
+    response = client.chat_completion(messages=[{"role": "user", "content": "Hello"}])
+    
+    assert response.success is True
+    assert response.content == "Atomic Response"
+    # Atomic call should NOT affect internal messages
+    assert len(client.messages) == 0
+
+def test_openai_chat_ask_success(mock_openai_chat):
+    """Tests high-level ask method with a simple response."""
+    mock_instance = mock_openai_chat.return_value
+    m = MagicMock()
+    m.choices = [MagicMock(message=MagicMock(content="Hello", tool_calls=None))]
+    m.usage = None
+    mock_instance.chat.completions.create.return_value = m
+    
+    client = OpenAIChat(api_key="test-key")
+    response = client.ask("Hi", stream=False)
     
     assert isinstance(response, LLMResponse)
     assert response.success is True
     assert response.content == "Hello"
     assert len(client.messages) == 2
 
+def test_openai_chat_ask_stream_success(mock_openai_chat):
+    """Tests high-level ask method with streaming output."""
+    mock_instance = mock_openai_chat.return_value
+    
+    # Mock streaming chunks
+    c1 = MagicMock()
+    # Explicitly set reasoning_content to avoid Mock truthiness
+    c1.choices = [MagicMock(delta=MagicMock(content="Hello", tool_calls=None, reasoning_content=None))]
+    c1.usage = None
+    
+    c2 = MagicMock()
+    c2.choices = []
+    c2.usage = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    
+    mock_instance.chat.completions.create.return_value = [c1, c2]
+    
+    client = OpenAIChat(api_key="test-key")
+    response_gen = client.ask("Hi", stream=True)
+    
+    chunks = list(response_gen)
+    # Expected: 1. Chunk with "Hello", 2. Final Chunk with usage
+    assert len(chunks) == 2
+    assert chunks[0].content == "Hello"
+    assert chunks[1].content == ""
+    assert chunks[1].usage.total_tokens == 15
+    assert len(client.messages) == 2
+
 def test_openai_chat_multi_turn_tool(mock_openai_chat):
+    """Tests recursive tool calling in ask loop."""
     def tool_a(x: int): return True, f"Done {x}"
     tool_def = {
         "type": "function",
@@ -42,30 +89,34 @@ def test_openai_chat_multi_turn_tool(mock_openai_chat):
     mock_instance = mock_openai_chat.return_value
     
     # Round 1: Model calls tool
+    m1 = MagicMock()
     tc = MagicMock()
-    tc.index = 0
     tc.id = "c1"
     tc.function.name = "tool_a"
     tc.function.arguments = '{"x": 1}'
-    m1 = MagicMock(choices=[MagicMock(delta=MagicMock(content=None, tool_calls=[tc]))], usage=None)
+    m1.choices = [MagicMock(message=MagicMock(content=None, tool_calls=[tc]))]
+    m1.usage = None
     
     # Round 2: Model gives final answer
-    m2 = MagicMock(choices=[MagicMock(delta=MagicMock(content="Finished", tool_calls=None))], usage=None)
+    m2 = MagicMock()
+    m2.choices = [MagicMock(message=MagicMock(content="Finished", tool_calls=None))]
+    m2.usage = None
     
-    mock_instance.chat.completions.create.side_effect = [[m1], [m2]]
+    mock_instance.chat.completions.create.side_effect = [m1, m2]
     
-    response = client.ask("Run tool")
+    response = client.ask("Run tool", stream=False)
     assert response.content == "Finished"
     assert mock_instance.chat.completions.create.call_count == 2
     assert client.latest_tool_call_result["tool_a"] is True
 
 def test_openai_chat_safe_state_on_error(mock_openai_chat):
+    """Verifies that conversation history is preserved on API failure."""
     mock_instance = mock_openai_chat.return_value
     mock_instance.chat.completions.create.side_effect = Exception("API Down")
     
     client = OpenAIChat(api_key="test-key", instructions="System")
     initial_len = len(client.messages)
     
-    response = client.ask("Fail me")
+    response = client.ask("Fail me", stream=False)
     assert response.success is False
-    assert len(client.messages) == initial_len # Should NOT have user/error messages added
+    assert len(client.messages) == initial_len

--- a/test/llm/providers/test_openai_chat.py
+++ b/test/llm/providers/test_openai_chat.py
@@ -1,5 +1,13 @@
 #! python3
-# -*- coding: utf-8 -*-
+# -*- encoding: utf-8 -*-
+"""
+@File   :   test_openai_chat.py
+@Created:   2026/06/05 00:13
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+# Here put the import lib.
 from unittest.mock import MagicMock, patch
 import pytest
 from PIL import Image

--- a/test/llm/tools/test_base.py
+++ b/test/llm/tools/test_base.py
@@ -1,0 +1,99 @@
+#! python3
+# -*- encoding: utf-8 -*-
+"""
+@File   :   test_base.py
+@Created:   2026/06/19 03:06
+@Author :   SwordJack
+@Contact:   https://github.com/SwordJack/
+"""
+
+import pytest
+from typing import Any, Dict, List, Optional
+from ark.llm.tools.base import FunctionTool, ToolSet
+
+def test_function_tool_auto_schema_basic():
+    """Tests basic auto-generation of schema from a simple function."""
+    def calculate_sum(a: int, b: int) -> int:
+        """Adds two numbers."""
+        return a + b
+
+    tool = FunctionTool(mapped_callable=calculate_sum)
+
+    assert tool.name == "calculate_sum"
+    assert tool.description == "Adds two numbers."
+    assert tool.parameters_schema == {
+        "type": "object",
+        "properties": {
+            "a": {"type": "integer"},
+            "b": {"type": "integer"}
+        },
+        "required": ["a", "b"]
+    }
+
+def test_function_tool_auto_schema_with_docstring_params():
+    """Tests auto-generation extracting parameter descriptions from docstrings."""
+    def get_user_info(user_id: int, include_email: bool = False):
+        """Fetches user information from the database.
+
+        Args:
+            user_id: The unique identifier for the user.
+            include_email (bool): Whether to include the email in the response.
+        """
+        pass
+
+    tool = FunctionTool(mapped_callable=get_user_info)
+
+    assert tool.name == "get_user_info"
+    assert tool.description == "Fetches user information from the database."
+    assert tool.parameters_schema == {
+        "type": "object",
+        "properties": {
+            "user_id": {
+                "type": "integer",
+                "description": "The unique identifier for the user."
+            },
+            "include_email": {
+                "type": "boolean",
+                "description": "Whether to include the email in the response."
+            }
+        },
+        "required": ["user_id"] # include_email has a default, so it's not required
+    }
+
+def test_function_tool_auto_schema_missing_types_and_docs():
+    """Tests behavior when types and param docs are missing."""
+    def mysterious_function(x, y="default"):
+        pass
+
+    tool = FunctionTool(mapped_callable=mysterious_function)
+
+    assert tool.name == "mysterious_function"
+    assert tool.description == ""
+    assert tool.parameters_schema == {
+        "type": "object",
+        "properties": {
+            "x": {"type": "string"}, # Defaults to string if no type hint
+            "y": {"type": "string"}
+        },
+        "required": ["x"]
+    }
+
+def test_function_tool_auto_schema_complex_types():
+    """Tests type mapping for lists and dicts."""
+    def process_data(items: list, metadata: dict, flag: bool):
+        """Processes complex data structures."""
+        pass
+
+    tool = FunctionTool(mapped_callable=process_data)
+
+    assert tool.parameters_schema["properties"]["items"]["type"] == "array"
+    assert tool.parameters_schema["properties"]["metadata"]["type"] == "object"
+    assert tool.parameters_schema["properties"]["flag"]["type"] == "boolean"
+    assert tool.parameters_schema["required"] == ["items", "metadata", "flag"]
+
+def test_toolset_execute_one_not_found():
+    """ToolSet handles missing tools gracefully."""
+    ts = ToolSet([])
+    is_success, output = ts._ToolSet__execute_one("missing_tool", "{}")
+    assert is_success is False
+    assert "not found" in output


### PR DESCRIPTION
Hi all,

This PR introduces a comprehensive refactoring and architectural standardization of the Agile Resource Kernel (ARK) LLM integration layer (`ark/llm`). By shifting the codebase to a strict **Data -> Logic -> Adapters** architecture, we achieve deep vendor neutrality between supported LLM providers.

The primary achievements of this refactoring include:

1. **The introduction of a provider-neutral `ToolCall` Data Transfer Object (DTO)**, decoupling the core execution logic from vendor-specific payload structures.
2. **Automatic JSON Schema generation** directly from Python callable signatures and docstrings via runtime inspection, with full support for explicit manual overrides.
3. **Decoupling of vendor-specific schema translations** entirely into the adapter layer (`OpenAIChat` and `AnthropicMessages`), ensuring the core tool calling logic (`ToolSet` and `FunctionTool`) remains unpolluted by provider-specific details.
4. **Comprehensive documentation and verification tests**, including manual live testing harnesses and robust mocked unit tests.

---

## Architectural Design

The updated architecture enforces a clean separation of concerns, ensuring that introducing additional providers (e.g., Gemini, DeepSeek) will not require modifications to the tool engine or calling workflows.

```text
       [ workflow / user code ]
                  │
                  ▼ (asks for generation/orchestration)
        ┌───────────────────┐
        │  BaseLLMClient    │ ◄─── (returns LLMResponse DTO)
        └─────────┬─────────┘
                  │ (uses / coordinates)
                  ├──────────────────────────────┐
                  ▼                              ▼
        ┌───────────────────┐          ┌──────────────────┐
        │     ToolSet       │          │   FunctionTool   │
        └─────────┬─────────┘          └────────┬─────────┘
                  │ (executes)                  │ (translates schema)
                  ▼                             ▼
            [ python callables ]         [ Providers / Adapters ]
                                         - OpenAIChat
                                         - AnthropicMessages
```

### 1. Data Layer (`ark/llm/entities.py`)

Provides pure, vendor-agnostic DTOs for data boundaries:

- `LLMResponse`: Standardized structure containing output text (`content`), raw response, success indicators, reasoning text, and a list of parsed `ToolCall` objects.
- `TokenUsage`: Standardized token tracking (`input_tokens`, `output_tokens`, `total_tokens`).
- `ToolCall`: A flat representation of a function invocation requested by an LLM, containing a unique `id`, the target function `name`, and serialized JSON `arguments`.

### 2. Logic Layer (`ark/llm/tools/base.py`)

Contains the local core execution capability:

- `FunctionTool`: Represents a tool capability. It serves as the single source of truth for name, description, and parameter structure.
- `ToolSet`: Blindly coordinates execution of `ToolCall` payloads and handles exceptions. It has no concept of OpenAI message formats or Anthropic blocks.

### 3. Adapter Layer (`ark/llm/providers/`)

Implements actual API calls and encapsulates format translation right before network boundary transmission:

- `OpenAIChat` (`ark/llm/providers/openai_chat.py`): Translates neutral schemas into OpenAI's tool/function schemas, executes chat-completions, and maps OpenAI's `tool_calls` array into neutral `ToolCall` lists.
- `AnthropicMessages` (`ark/llm/providers/anthropic_messages.py`): Formulates Anthropic tool blocks from neutral definitions, formats execution outputs as nested `tool_result` blocks in a user turn, preserves reasoning/thinking steps, and maps Anthropic tool uses into standard `ToolCall` lists.

---

## Key Improvements & Features

### 1. Automatic JSON Schema Generation with Overrides

`FunctionTool` inspects Python function signatures via `inspect.signature` and maps python types to JSON Schema equivalents. It extracts parameter descriptions from docstrings dynamically:

```python
def get_weather(city: str) -> Tuple[bool, str]:
    """Get the current weather for a city.

    Args:
        city: The name of the city.
    """
    return True, f"Sunny in {city}."

# Auto-generates name, description, parameter schemas, and marks non-default arguments as required
tool = FunctionTool(get_weather)
```

For scenarios requiring strict parameter constraints, developers can supply explicit overrides that completely bypass automatic generation:

```python
tool = FunctionTool(
    mapped_callable=get_weather,
    name="get_weather_custom",
    description="Custom weather description",
    parameters_schema={
        "type": "object",
        "properties": {"city": {"type": "string", "description": "City name"}},
        "required": ["city"]
    }
)
```

### 2. Decoupling of Vendor-Specific Schema Translations

Both adapters convert the neutral `parameters_schema` dynamically on the fly before API requests are made.

- **OpenAI** formats them as:
  ```json
  {"type": "function", "function": {"name": ..., "description": ..., "parameters": ...}}
  ```
- **Anthropic** maps them to:
  ```json
  {"name": ..., "description": ..., "input_schema": ...}
  ```

### 3. Streamlined Multi-Turn Orchestration

The client `ask()` orchestration loop manages conversation history across multiple tool-calling turns. If the model emits a tool call, the adapter layer captures it, delegates execution to `ToolSet.execute_tool_calls`, compiles the execution output into vendor-native message blocks (such as `tool_result` blocks for Anthropic and `role: tool` messages for OpenAI), and feeds them back recursively up to `max_tool_rounds`.

### 4. Resilient Stream Accumulation

The Anthropic provider includes a hand-rolled stream accumulation layer to accommodate custom/compatible gateway behaviors. This protects the pipeline from crashing when compatible endpoints yield non-conformant `message_start.content: null` chunks.

---

## Relevant File Paths

The following absolute file paths under `/home/yinjie/repositories/IsoBase/` define and support this integration:

- **Core Implementation**:
  - `ark/llm/entities.py` — Standardized data structures (`LLMResponse`, `ToolCall`, `TokenUsage`).
  - `ark/llm/tools/base.py` — `FunctionTool` (schema generator + executor) and `ToolSet`.
  - `ark/llm/providers/base.py` — `BaseLLMClient` abstract interface and image helper signatures.
  - `ark/llm/providers/openai_chat.py` — Chat Completion compatible adapter.
  - `ark/llm/providers/anthropic_messages.py` — Messages API compatible adapter.
- **Documentation**:
  - `ark/llm/README.md` — Detailed module documentation.
  - `ark/llm/README.zh-cn.md` — Simplified Chinese documentation.
  - `CLAUDE.md` — Project context and core coding rules updated with `ark/llm` guidelines.
- **Testing & Verification**:
  - `test/llm/tools/test_base.py` — Unit tests for schema generation, parameter extraction, and tool execution.
  - `test/llm/providers/test_openai_chat.py` — Mock-based integration tests for OpenAI tool calls and streaming.
  - `test/llm/providers/test_anthropic_messages.py` — Mock-based integration tests for Anthropic tool calls, thinking, and streaming.
  - `test/llm/live/run_live.py` — Verification script for live multi-turn run checks with external APIs.

---

## Verification and Testing Plan

All automated verification checks have run and passed.

1. **Unit Tests**:
   Ensure all logic, parsing, automatic parameter mapping, and mock behaviors function correctly by executing tests from the repo root:
   ```bash
   python -m pytest test/llm/tools/test_base.py
   python -m pytest test/llm/providers/test_openai_chat.py
   python -m pytest test/llm/providers/test_anthropic_messages.py
   ```
2. **Manual Live Integration Smoke Tests**:
   Live multi-turn agent execution loops (verifying streaming tokens, markdown generation, image ingestion, and tool fallback execution) have been successfully run via the live runner script:
   ```bash
   cd test/llm/live
   cp .env.example .env # populated with valid keys
   python -m test.llm.live.run_live
   ```

Best,
SwordJack.