### PR TITLE
Swordjack: Feature Provider `ask` Overload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,6 @@ For multi-step tasks, state a brief plan:
 **Environment & Testing**:
 
 - Python 3.13 via conda. Setup: `conda env create -f environment.yml && conda activate isobase`
-- _Note: `Pillow` is required but missing from `environment.yml`. Install it manually if needed._
 - Tests use `pytest` and **must** be run from the repo root:
   - `python -m pytest` (all tests)
   - `python -m pytest test/workflow/test_workflow.py` (specific file)

--- a/docs/design/overload_vs_dispatch.md
+++ b/docs/design/overload_vs_dispatch.md
@@ -1,0 +1,147 @@
+# Overload vs Dispatch in Python: A Pragmatic Engineering Guide
+
+In dynamically typed languages like Python, developers constantly balance two competing needs:
+
+1. **Static Developer Experience (DX)**: Providing perfect autocomplete and type warnings in IDEs (VSCode/PyCharm) before the code ever runs.
+2. **Dynamic Runtime Elegance**: Writing clean, extensible logic that avoids massive `if isinstance(...)` blocks when the code actually executes.
+
+This document serves as an architectural reference, capturing the trade-offs between `typing.overload` and `functools.singledispatch`, and how `IsoBase` makes pragmatic choices between them.
+
+---
+
+## 1. `@overload`: The Static "Mirage"
+
+Introduced in Python 3.5 via the `typing` module, `@overload` solves a specific problem: **how to tell the IDE that a function's return type changes depending on its input parameters.**
+
+### How It Works
+
+You write multiple "stub" functions adorned with `@overload`. These stubs contain no actual logic (just `pass` or `...`). They are strictly for the type checker. You must follow them with one "fat" implementation function that actually does the work.
+
+```python
+from typing import overload, Union
+
+@overload
+def parse_data(data: str) -> dict: ...
+
+@overload
+def parse_data(data: int) -> list: ...
+
+# The "Fat Body" (Runtime Implementation)
+def parse_data(data: Union[str, int]) -> Union[dict, list]:
+    if isinstance(data, str):
+        return {"result": data}
+    elif isinstance(data, int):
+        return [data, data]
+    raise TypeError("Unsupported type")
+```
+
+### The Pain Points of Overload
+
+1. **The Spaghetti Code Problem**: While the IDE is happy, your runtime code is forced into a single, massive function body filled with `if isinstance(...)` branches. This violates the Open-Closed Principle.
+2. **Type Checker Tyranny**: Strict type checkers like `mypy` demand that your implementation signature perfectly subsumes all overload signatures. Minor mismatches lead to confusing static errors.
+3. **Overlapping Signatures**: If two overloads have similar parameter types but different return types (e.g., `Any` vs `int`), the IDE may fail to resolve the correct one, collapsing back to a messy `Union`.
+
+---
+
+## 2. `@singledispatch`: The Runtime "Router"
+
+To solve the "Fat Body" spaghetti code issue, Python's standard library provides `@functools.singledispatch`.
+
+### How It Works
+
+It allows you to break a massive `if-else` block into clean, isolated functions. Python automatically routes the execution to the correct function based on the **type** of the first argument at runtime.
+
+```python
+from functools import singledispatch
+
+@singledispatch
+def parse_data(data):
+    raise TypeError(f"Unsupported type: {type(data)}")
+
+@parse_data.register(str)
+def _(data: str) -> dict:
+    return {"result": data}
+
+@parse_data.register(int)
+def _(data: int) -> list:
+    return [data, data]
+```
+
+### The Strengths and Weaknesses
+
+- **Strengths**: Perfect runtime decoupling. External developers can add support for their own custom classes simply by importing your function and using `@parse_data.register(CustomClass)`, completely without modifying your source code.
+- **Weaknesses**: **Terrible IDE Support.** Because the entry point `parse_data(data)` lacks a specific return type, the IDE has no idea what will be returned when the user types `parse_data("hello")`.
+
+---
+
+## 3. The Ultimate Pattern: Overload + Dispatch Fusion
+
+For high-end framework development (like Pydantic or FastAPI core internals) dealing with dozens of data types, the industry best practice is to **combine both**.
+
+Use `@overload` as the "Face" (to trick the IDE into providing perfect hints) and `@singledispatch` as the "Engine" (to cleanly route execution at runtime).
+
+```python
+from functools import singledispatch
+from typing import overload
+
+# 1. The Face: Static Stubs for the IDE
+@overload
+def process(data: str) -> dict: ...
+
+@overload
+def process(data: int) -> list: ...
+
+# 2. The Engine Entrypoint: Dynamic Runtime Dispatcher
+@singledispatch
+def process(data):
+    raise TypeError("Unsupported type")
+
+# 3. The Engine Workers: Concrete Implementations
+@process.register(str)
+def _(data: str) -> dict:
+    return {"status": "ok", "value": data}
+
+@process.register(int)
+def _(data: int) -> list:
+    return [data]
+```
+
+With this architecture:
+
+- The IDE provides precise autocomplete based on the `@overload` stubs.
+- The runtime execution routes seamlessly via `@singledispatch` without a single `isinstance` check.
+
+---
+
+## 4. Pragmatism in IsoBase: Why We Chose `if-else` for `ask()`
+
+In `IsoBase` (`isobase/llm/providers/base.py`), the `ask` method's return type changes based on the `stream` parameter:
+
+- `stream=False` ➔ returns `LLMResponse`
+- `stream=True` ➔ returns `Iterator[LLMResponse]`
+
+We used the `@overload` decorator to fix the IDE autocomplete:
+
+```python
+@overload
+def ask(self, prompt: str, stream: Literal[False] = False, **kwargs) -> LLMResponse: ...
+
+@overload
+def ask(self, prompt: str, stream: Literal[True], **kwargs) -> Iterator[LLMResponse]: ...
+```
+
+However, for the actual implementation, we deliberately **avoided** dynamic dispatch and stuck to a simple `if-else`:
+
+```python
+def ask(self, prompt: str, stream: bool = False, **kwargs):
+    if stream:
+        return self._ask_loop_stream(...)
+    else:
+        return self._ask_loop(...)
+```
+
+### Why not use Dispatch here?
+
+1. **Value vs. Type Routing**: `@singledispatch` only routes based on **types** (e.g., `str` vs `int`). It cannot route based on specific **values** (e.g., `True` vs `False`).
+2. **Avoiding Over-Engineering**: While we could have implemented a Custom Strategy Pattern (e.g., mapping boolean values to functions in a dictionary: `router = {True: _ask_stream, False: _ask}`), doing so for a simple binary choice obscures the code.
+3. **KISS Principle**: When faced with dozens of type branches, dispatch is king. When faced with exactly two states (`True`/`False`), `@overload` + `if-else` remains the most readable, Pythonic, and pragmatic choice.

--- a/isobase/llm/README.md
+++ b/isobase/llm/README.md
@@ -132,6 +132,8 @@ class MyUIUpdater(BaseLLMCallback):
 client.ask("Latest news in Tokyo", callbacks=[MyUIUpdater()])
 ```
 
+### 4. Extended thinking (Anthropic)
+
 ```python
 client = AnthropicMessages(api_key="sk-ant-...", thinking={"type": "adaptive"})
 resp = client.ask("Solve 27 * 453 step by step.")
@@ -142,7 +144,7 @@ print(resp.content)            # final answer
 ## Module Structure
 
 - `entities.py` — `LLMResponse`, `TokenUsage`, and `ToolCall` dataclasses; the standardized provider-neutral data types used for inputs and returns.
-- `providers/base.py` — `BaseLLMClient` abstract interface (`generate`, `generate_stream`) plus `build_user_message_content` for multimodal messages.
+- `providers/base.py` — `BaseLLMClient` abstract interface (`ask`, `generate`, `generate_stream`) plus `build_user_message_content` for multimodal messages.
 - `providers/openai_chat.py` — `OpenAIChat`, the OpenAI Chat Completion compatible client.
 - `providers/anthropic_messages.py` — `AnthropicMessages`, the Anthropic Messages compatible client (named after the Messages API, mirroring how `OpenAIChat` is named after the Chat Completion API).
 - `tools/base.py` — `FunctionTool`, `ToolSet`; the neutral tool representation and execution engine.
@@ -150,7 +152,7 @@ print(resp.content)            # final answer
 
 Image helpers live in `isobase/core/image_service.py` (`convert_image_to_data_url` for OpenAI, `convert_image_to_base64` for Anthropic).
 
-Manual live API smoke tests (not run by pytest) live in `test/llm/live/` — copy `.env.example` to `.env`, fill in credentials, and run `python -m test.llm.live.run_live`.
+Manual live API smoke tests (not run by pytest) live in `test/llm/live/` — copy `.env.example` to `.env`, fill in credentials, and run `python -m test.llm.live.run_llm_basic`.
 
 ## Status
 

--- a/isobase/llm/README.zh-cn.md
+++ b/isobase/llm/README.zh-cn.md
@@ -145,7 +145,7 @@ print(resp.content)            # 最终回答
 ## 模块结构
 
 - `entities.py` —— `LLMResponse`、`TokenUsage` 与 `ToolCall` 数据类；用作输入和每个客户端方法的标准化返回类型。
-- `providers/base.py` —— `BaseLLMClient` 抽象接口（`generate`、`generate_stream`）以及用于多模态消息的 `build_user_message_content`。
+- `providers/base.py` —— `BaseLLMClient` 抽象接口（`ask`、`generate`、`generate_stream`）以及用于多模态消息的 `build_user_message_content`。
 - `providers/openai_chat.py` —— `OpenAIChat`，OpenAI Chat Completion 兼容客户端。
 - `providers/anthropic_messages.py` —— `AnthropicMessages`，Anthropic Messages 兼容客户端（按其对接的 Messages API 命名，与 `OpenAIChat` 按 Chat Completion API 命名同理）。
 - `tools/base.py` —— `FunctionTool` 与 `ToolSet`；中立工具表示及执行引擎。
@@ -153,7 +153,7 @@ print(resp.content)            # 最终回答
 
 图像辅助函数位于 `isobase/core/image_service.py`（`convert_image_to_data_url` 供 OpenAI，`convert_image_to_base64` 供 Anthropic）。
 
-手动真实 API 冒烟测试（不由 pytest 收集）位于 `test/llm/live/` —— 把 `.env.example` 复制为 `.env`、填入凭据，运行 `python -m test.llm.live.run_live`。
+手动真实 API 冒烟测试（不由 pytest 收集）位于 `test/llm/live/` —— 把 `.env.example` 复制为 `.env`、填入凭据，运行 `python -m test.llm.live.run_llm_basic`。
 
 ## 进度
 

--- a/isobase/llm/providers/anthropic_messages.py
+++ b/isobase/llm/providers/anthropic_messages.py
@@ -33,7 +33,7 @@ Key Anthropic-specific handling versus OpenAI:
 
 from inspect import signature
 from json import dumps
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Tuple, Union, overload
 
 from anthropic import Anthropic, BadRequestError
 # Reuse the SDK's own streaming accumulator instead of hand-rolling block
@@ -161,6 +161,24 @@ class AnthropicMessages(BaseLLMClient):
                 },
             })
         return content
+
+    @overload
+    def ask(self,
+            prompt: str,
+            images: Optional[List[PILImage.Image]] = None,
+            stream: Literal[False] = False,
+            callbacks: Optional[List[BaseLLMCallback]] = None,
+            **kwargs: Any) -> LLMResponse:
+        ...
+
+    @overload
+    def ask(self,
+            prompt: str,
+            images: Optional[List[PILImage.Image]] = None,
+            stream: Literal[True] = True,
+            callbacks: Optional[List[BaseLLMCallback]] = None,
+            **kwargs: Any) -> Iterator[LLMResponse]:
+        ...
 
     def ask(self,
             prompt: str,

--- a/isobase/llm/providers/anthropic_messages.py
+++ b/isobase/llm/providers/anthropic_messages.py
@@ -162,47 +162,6 @@ class AnthropicMessages(BaseLLMClient):
             })
         return content
 
-    @overload
-    def ask(self,
-            prompt: str,
-            images: Optional[List[PILImage.Image]] = None,
-            stream: Literal[False] = False,
-            callbacks: Optional[List[BaseLLMCallback]] = None,
-            **kwargs: Any) -> LLMResponse:
-        ...
-
-    @overload
-    def ask(self,
-            prompt: str,
-            images: Optional[List[PILImage.Image]] = None,
-            stream: Literal[True] = True,
-            callbacks: Optional[List[BaseLLMCallback]] = None,
-            **kwargs: Any) -> Iterator[LLMResponse]:
-        ...
-
-    def ask(self,
-            prompt: str,
-            images: Optional[List[PILImage.Image]] = None,
-            stream: bool = False,
-            callbacks: Optional[List[BaseLLMCallback]] = None,
-            **kwargs: Any) -> Union[LLMResponse, Iterator[LLMResponse]]:
-        """Orchestrates a chat interaction, handling history and tool calls.
-
-        Args:
-            prompt (str): The user's input text.
-            images (Optional[List[PILImage.Image]]): Optional images for multimodal input.
-            stream (bool, optional): Whether to use streaming. Defaults to False.
-            callbacks: Optional list of callback handlers.
-            **kwargs: Additional parameters for the model.
-
-        Returns:
-            An LLMResponse (non-stream) or Iterator[LLMResponse] (stream).
-        """
-        if stream:
-            return self.__ask_loop_stream(prompt, images, callbacks=callbacks, **kwargs)
-        else:
-            return self.__ask_loop(prompt, images, callbacks=callbacks, **kwargs)
-
     def generate(self,
             messages: List[Dict[str, Any]],
             model: Optional[str] = None,
@@ -363,7 +322,7 @@ class AnthropicMessages(BaseLLMClient):
             raw_response=snapshot
         )
 
-    def __ask_loop(self,
+    def _ask_loop(self,
                   prompt: str,
                   images: Optional[List[PILImage.Image]] = None,
                   callbacks: Optional[List[BaseLLMCallback]] = None,
@@ -466,7 +425,7 @@ class AnthropicMessages(BaseLLMClient):
         except Exception as e:
             return self.__handle_ask_exception(e)
 
-    def __ask_loop_stream(self,
+    def _ask_loop_stream(self,
                          prompt: str,
                          images: Optional[List[PILImage.Image]] = None,
                          callbacks: Optional[List[BaseLLMCallback]] = None,

--- a/isobase/llm/providers/base.py
+++ b/isobase/llm/providers/base.py
@@ -76,7 +76,6 @@ class BaseLLMClient(ABC):
             **kwargs: Any) -> Iterator[LLMResponse]:
         ...
 
-    @abstractmethod
     def ask(self,
             prompt: str,
             images: Optional[List[PILImage.Image]] = None,
@@ -94,6 +93,47 @@ class BaseLLMClient(ABC):
 
         Returns:
             An LLMResponse (non-stream) or Iterator[LLMResponse] (stream).
+        """
+        if stream:
+            return self._ask_loop_stream(prompt, images, callbacks=callbacks, **kwargs)
+        else:
+            return self._ask_loop(prompt, images, callbacks=callbacks, **kwargs)
+
+    @abstractmethod
+    def _ask_loop(self,
+                  prompt: str,
+                  images: Optional[List[PILImage.Image]] = None,
+                  callbacks: Optional[List[BaseLLMCallback]] = None,
+                  **kwargs: Any) -> LLMResponse:
+        """Internal loop for non-streaming interaction.
+
+        Args:
+            prompt: User prompt.
+            images: Multimodal inputs.
+            callbacks: Optional list of callback handlers.
+            **kwargs: API arguments.
+
+        Returns:
+            Final LLMResponse after all tool calls.
+        """
+        pass
+
+    @abstractmethod
+    def _ask_loop_stream(self,
+                         prompt: str,
+                         images: Optional[List[PILImage.Image]] = None,
+                         callbacks: Optional[List[BaseLLMCallback]] = None,
+                         **kwargs: Any) -> Iterator[LLMResponse]:
+        """Internal loop for streaming interaction.
+
+        Args:
+            prompt: User prompt.
+            images: Multimodal inputs.
+            callbacks: Optional list of callback handlers.
+            **kwargs: API arguments.
+
+        Yields:
+            Incremental chunks and a final summary per round.
         """
         pass
 

--- a/isobase/llm/providers/base.py
+++ b/isobase/llm/providers/base.py
@@ -9,7 +9,7 @@
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Literal, Optional, Union, overload
 
 from PIL import Image as PILImage
 
@@ -57,6 +57,24 @@ class BaseLLMClient(ABC):
             LLMResponse objects containing incremental content chunks.
         """
         pass
+
+    @overload
+    def ask(self,
+            prompt: str,
+            images: Optional[List[PILImage.Image]] = None,
+            stream: Literal[False] = False,
+            callbacks: Optional[List[BaseLLMCallback]] = None,
+            **kwargs: Any) -> LLMResponse:
+        ...
+
+    @overload
+    def ask(self,
+            prompt: str,
+            images: Optional[List[PILImage.Image]] = None,
+            stream: Literal[True] = True,
+            callbacks: Optional[List[BaseLLMCallback]] = None,
+            **kwargs: Any) -> Iterator[LLMResponse]:
+        ...
 
     @abstractmethod
     def ask(self,

--- a/isobase/llm/providers/openai_chat.py
+++ b/isobase/llm/providers/openai_chat.py
@@ -9,7 +9,7 @@
 """
 
 from inspect import signature
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Tuple, Union, overload
 
 from openai import (
     BadRequestError,
@@ -90,6 +90,24 @@ class OpenAIChat(BaseLLMClient):
         }
 
         LOGGER.info(f"OpenAIChat initialized (model: {default_model})")
+
+    @overload
+    def ask(self,
+            prompt: str,
+            images: Optional[List[PILImage.Image]] = None,
+            stream: Literal[False] = False,
+            callbacks: Optional[List[BaseLLMCallback]] = None,
+            **kwargs: Any) -> LLMResponse:
+        ...
+
+    @overload
+    def ask(self,
+            prompt: str,
+            images: Optional[List[PILImage.Image]] = None,
+            stream: Literal[True] = True,
+            callbacks: Optional[List[BaseLLMCallback]] = None,
+            **kwargs: Any) -> Iterator[LLMResponse]:
+        ...
 
     def ask(self,
             prompt: str,

--- a/isobase/llm/providers/openai_chat.py
+++ b/isobase/llm/providers/openai_chat.py
@@ -502,10 +502,10 @@ class OpenAIChat(BaseLLMClient):
 
         1. `dict`: Raw dictionaries typically generated during mid-stream accumulation.
         2. `ToolCall`: IsoBase's provider-neutral dataclass. Yielded at the end of
-           `generate_stream` (in `__ask_loop_stream`). Since it is provider-neutral,
+           `generate_stream` (in `_ask_loop_stream`). Since it is provider-neutral,
            it lacks OpenAI-specific fields like `type`, so we manually inject `"type": "function"`.
         3. `ChoiceMessageToolCall`: Native OpenAI SDK objects returned in non-streaming
-           (`__ask_loop`). It uses `getattr` for safe access and `model_dump()` to
+           (`_ask_loop`). It uses `getattr` for safe access and `model_dump()` to
            preserve built-in native tools (like `web_search`) verbatim.
 
         Args:

--- a/isobase/llm/providers/openai_chat.py
+++ b/isobase/llm/providers/openai_chat.py
@@ -91,47 +91,6 @@ class OpenAIChat(BaseLLMClient):
 
         LOGGER.info(f"OpenAIChat initialized (model: {default_model})")
 
-    @overload
-    def ask(self,
-            prompt: str,
-            images: Optional[List[PILImage.Image]] = None,
-            stream: Literal[False] = False,
-            callbacks: Optional[List[BaseLLMCallback]] = None,
-            **kwargs: Any) -> LLMResponse:
-        ...
-
-    @overload
-    def ask(self,
-            prompt: str,
-            images: Optional[List[PILImage.Image]] = None,
-            stream: Literal[True] = True,
-            callbacks: Optional[List[BaseLLMCallback]] = None,
-            **kwargs: Any) -> Iterator[LLMResponse]:
-        ...
-
-    def ask(self,
-            prompt: str,
-            images: Optional[List[PILImage.Image]] = None,
-            stream: bool = False,
-            callbacks: Optional[List[BaseLLMCallback]] = None,
-            **kwargs: Any) -> Union[LLMResponse, Iterator[LLMResponse]]:
-        """Orchestrates a chat interaction, handling history and tool calls.
-
-        Args:
-            prompt (str): The user's input text.
-            images (Optional[List[PILImage.Image]]): Optional list of images for multimodal input.
-            stream (bool, optional): Whether to use streaming for the interaction. Defaults to False.
-            callbacks: Optional list of callback handlers.
-            **kwargs: Additional parameters for the model.
-
-        Returns:
-            An LLMResponse (non-stream) or Iterator[LLMResponse] (stream).
-        """
-        if stream:
-            return self.__ask_loop_stream(prompt, images, callbacks=callbacks, **kwargs)
-        else:
-            return self.__ask_loop(prompt, images, callbacks=callbacks, **kwargs)
-
     def generate(self,
             messages: List[Dict[str, str]],
             model: Optional[str] = None,
@@ -254,7 +213,7 @@ class OpenAIChat(BaseLLMClient):
             usage=usage
         )
 
-    def __ask_loop(self,
+    def _ask_loop(self,
                   prompt: str,
                   images: Optional[List[PILImage.Image]] = None,
                   callbacks: Optional[List[BaseLLMCallback]] = None,
@@ -345,7 +304,7 @@ class OpenAIChat(BaseLLMClient):
         except Exception as e:
             return self.__handle_ask_exception(e)
 
-    def __ask_loop_stream(self,
+    def _ask_loop_stream(self,
                          prompt: str,
                          images: Optional[List[PILImage.Image]] = None,
                          callbacks: Optional[List[BaseLLMCallback]] = None,

--- a/test/llm/live/run_agent_complex.py
+++ b/test/llm/live/run_agent_complex.py
@@ -175,12 +175,27 @@ def _run_complex_scenarios(llm_client: LLMClient, prompt: str):
 
     print("\n[Response Stream Starts]:\n")
     # Stream mode loop which processes chunks sequentially as they arrive
+    in_reasoning = False
+
     for chunk in llm_client.ask(prompt, stream=True, callbacks=[cb]):
-        if chunk.content:
-            print(chunk.content, end="", flush=True)
-        # Note: If extended thinking is active, print it out
-        if getattr(chunk, "reasoning_content", None):
-            print(f"\033[90m{chunk.reasoning_content}\033[0m", end="", flush=True)
+        reasoning = getattr(chunk, "reasoning_content", None)
+        content = chunk.content
+
+        if reasoning:
+            if not in_reasoning:
+                print("\n🤔 [Thinking]:\n\033[90m", end="", flush=True)
+                in_reasoning = True
+            print(reasoning, end="", flush=True)
+
+        if content:
+            if in_reasoning:
+                print("\033[0m\n\n✨ [Output]:\n", end="", flush=True)
+                in_reasoning = False
+            print(content, end="", flush=True)
+
+    # Safety check to clear color formatting
+    if in_reasoning:
+        print("\033[0m", end="", flush=True)
 
     print("\n\n[Response Stream Ends]\n")
 

--- a/test/llm/live/run_agent_complex.py
+++ b/test/llm/live/run_agent_complex.py
@@ -178,14 +178,14 @@ def _run_complex_scenarios(llm_client: LLMClient, prompt: str):
     in_reasoning = False
 
     for chunk in llm_client.ask(prompt, stream=True, callbacks=[cb]):
-        reasoning = getattr(chunk, "reasoning_content", None)
+        reasoning_content = chunk.reasoning_content
         content = chunk.content
 
-        if reasoning:
+        if reasoning_content:
             if not in_reasoning:
                 print("\n🤔 [Thinking]:\n\033[90m", end="", flush=True)
                 in_reasoning = True
-            print(reasoning, end="", flush=True)
+            print(reasoning_content, end="", flush=True)
 
         if content:
             if in_reasoning:

--- a/test/llm/live/run_agent_search.py
+++ b/test/llm/live/run_agent_search.py
@@ -19,7 +19,7 @@ import sys
 from os import path
 from typing import Any, Dict, Optional
 
-from isobase.llm import OpenAIChat, AnthropicMessages
+from isobase.llm import LLMClient, OpenAIChat, AnthropicMessages
 from isobase.llm.tools.search import SearchTool, BraveSearchProvider, TavilySearchProvider
 
 ENV_PATH = path.join(path.dirname(__file__), ".env")
@@ -53,7 +53,7 @@ def _get_api_key(env: Dict[str, str], env_key: str) -> Optional[str]:
     return api_key
 
 
-def _run_agent_scenario(llm_client: Any, search_provider: Any, llm_name: str, search_name: str, query: str):
+def _run_agent_scenario(llm_client: LLMClient, search_provider: Any, llm_name: str, search_name: str, query: str):
     """Runs a with/without search scenario for a specific LLM + Search Provider combo."""
     print(f"\n{'=' * 80}")
     print(f"Testing Combination: {llm_name} + {search_name}")

--- a/test/llm/live/run_agent_tracer.py
+++ b/test/llm/live/run_agent_tracer.py
@@ -21,7 +21,7 @@ from os import path
 from typing import Any, Dict, List, Optional
 
 from isobase.core.logger import LOGGER
-from isobase.llm import OpenAIChat, AnthropicMessages
+from isobase.llm import LLMClient, OpenAIChat, AnthropicMessages
 from isobase.llm.entities import SearchResultItem
 from isobase.llm.tools.search import SearchTool, BraveSearchProvider, TavilySearchProvider
 from isobase.llm.entities import SearchResult
@@ -106,7 +106,7 @@ def wrap_client_with_tracer(client_instance: Any):
     client_instance.generate = traced_generate
 
 
-def _run_agent_scenario(llm_client: Any, search_provider: Any, llm_name: str, search_name: str, query: str):
+def _run_agent_scenario(llm_client: LLMClient, search_provider: Any, llm_name: str, search_name: str, query: str):
     """Runs a with/without search scenario for a specific LLM + Search Provider combo."""
     print(f"\n{'=' * 80}")
     print(f"Testing Combination: {llm_name} + {search_name}")


### PR DESCRIPTION
Hi all,

This PR significantly improves the Developer Experience (DX) and maintains architectural cleanliness by promoting the `ask` orchestrator to `BaseLLMClient` and utilizing Python's `typing.overload`. It eliminates false IDE type warnings (e.g., Pylance/Mypy) when toggling between streaming and non-streaming responses, and fixes several documentation/comment drifts.

## Key Changes

- **Template Method Pattern applied to `BaseLLMClient`**:
  - The concrete `ask()` method is now centralized in `base.py`.
  - Providers (`OpenAIChat`, `AnthropicMessages`) now strictly implement the protected abstract methods `_ask_loop` and `_ask_loop_stream` instead of duplicating the `ask` routing logic.
- **Perfect IDE Autocomplete via `@overload`**:
  - Bound `stream=False` strictly to `LLMResponse`.
  - Bound `stream=True` strictly to `Iterator[LLMResponse]`.
- **Architectural Documentation**:
  - Created `docs/design/overload_vs_dispatch.md` to explain the design choice (why `@overload` + `if-else` was selected over `@singledispatch` for boolean flag routing).
- **Cleanup & Drift Resolution**:
  - Renamed double-underscore (`__ask_loop`) methods to protected single-underscore (`_ask_loop`) to avoid Python name mangling and support clean subclass overriding.
  - Updated English and Chinese `README.md` to reflect that `ask` is now part of the base client abstract interface.
  - Re-aligned internal test instruction documents to point to the newly renamed `run_llm_basic.py`.
  - Removed outdated `Pillow` missing warnings from `CLAUDE.md`.

## Testing

- The architecture is fully backward compatible.
- All 50 unit and integration tests successfully pass.
- Verified manual IDE type-hinting behavior locally.

Best,
SwordJack.